### PR TITLE
chore: introduce prettier

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,38 +4,38 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:import/typescript'
+    'plugin:import/typescript',
+    'plugin:prettier/recommended',
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   rules: {
-    indent: ['error', 2],
     'no-multiple-empty-lines': 'error',
-    quotes: ['error', 'single', { 'allowTemplateLiterals': true }],
+    quotes: ['error', 'single', { allowTemplateLiterals: true }],
     semi: 'off',
     '@typescript-eslint/semi': ['error', 'never'],
     '@typescript-eslint/member-delimiter-style': [
       'error',
       {
-        'multiline': {
-          'delimiter': 'none',
-          'requireLast': true
+        multiline: {
+          delimiter: 'none',
+          requireLast: true,
         },
-        'singleline': {
-          'delimiter': 'semi',
-          'requireLast': false
+        singleline: {
+          delimiter: 'semi',
+          requireLast: false,
         },
-        'multilineDetection': 'brackets'
-      }
+        multilineDetection: 'brackets',
+      },
     ],
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
-        'argsIgnorePattern': '^_',
-        'varsIgnorePattern': '^_',
-        'caughtErrorsIgnorePattern': '^_',
-        'destructuredArrayIgnorePattern': '^_'
-      }
-    ]
-  }
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      },
+    ],
+  },
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
     "@typescript-eslint/parser": "5.54.0",
     "cross-fetch": "3.1.5",
     "eslint": "8.35.0",
+    "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
     "happy-dom": "8.9.0",
     "msw": "1.1.0",
+    "prettier": "^2.8.4",
     "typescript": "4.9.5",
     "vite": "4.1.4",
     "vitest": "0.29.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,12 @@ specifiers:
   '@typescript-eslint/parser': 5.54.0
   cross-fetch: 3.1.5
   eslint: 8.35.0
+  eslint-config-prettier: ^8.7.0
   eslint-plugin-import: 2.27.5
+  eslint-plugin-prettier: ^4.2.1
   happy-dom: 8.9.0
   msw: 1.1.0
+  prettier: ^2.8.4
   typescript: 4.9.5
   vite: 4.1.4
   vitest: 0.29.2
@@ -21,9 +24,12 @@ devDependencies:
   '@typescript-eslint/parser': 5.54.0_ycpbpc6yetojsgtrx3mwntkhsu
   cross-fetch: 3.1.5
   eslint: 8.35.0
+  eslint-config-prettier: 8.7.0_eslint@8.35.0
   eslint-plugin-import: 2.27.5_ajyizmi44oc3hrc35l6ndh7p4e
+  eslint-plugin-prettier: 4.2.1_xprnzp4ul2bcpmfe73av4voica
   happy-dom: 8.9.0
   msw: 1.1.0_typescript@4.9.5
+  prettier: 2.8.4
   typescript: 4.9.5
   vite: 4.1.4_@types+node@18.14.2
   vitest: 0.29.2_happy-dom@8.9.0
@@ -1063,6 +1069,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /eslint-config-prettier/8.7.0_eslint@8.35.0:
+    resolution: {integrity: sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.35.0
+    dev: true
+
   /eslint-import-resolver-node/0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
@@ -1133,6 +1148,23 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
+
+  /eslint-plugin-prettier/4.2.1_xprnzp4ul2bcpmfe73av4voica:
+    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      eslint: '>=7.28.0'
+      eslint-config-prettier: '*'
+      prettier: '>=2.0.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.35.0
+      eslint-config-prettier: 8.7.0_eslint@8.35.0
+      prettier: 2.8.4
+      prettier-linter-helpers: 1.0.0
     dev: true
 
   /eslint-scope/5.1.1:
@@ -1274,6 +1306,10 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
+  /fast-diff/1.2.0:
+    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
   /fast-glob/3.2.12:
@@ -2165,6 +2201,19 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /prettier-linter-helpers/1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      fast-diff: 1.2.0
+    dev: true
+
+  /prettier/2.8.4:
+    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /pretty-format/27.5.1:

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -44,8 +44,7 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
 
   if (!result.apiKey) throw new Error('apiKey is required')
   if (!result.apiEndpoint) throw new Error('apiEndpoint is required')
-  if (!isValidUrl(result.apiEndpoint))
-    throw new Error('apiEndpoint is invalid')
+  if (!isValidUrl(result.apiEndpoint)) throw new Error('apiEndpoint is invalid')
   if (!result.featureTag) throw new Error('featureTag is required')
   if (!result.appVersion) throw new Error('appVersion is required')
 

--- a/src/BKTEvaluation.ts
+++ b/src/BKTEvaluation.ts
@@ -5,5 +5,11 @@ export interface BKTEvaluation {
   readonly userId: string
   readonly variationId: string
   readonly variationValue: string
-  readonly reason: 'TARGET' | 'RULE' | 'DEFAULT' | 'CLIENT' | 'OFF_VARIATION' | 'PREREQUISITE'
+  readonly reason:
+    | 'TARGET'
+    | 'RULE'
+    | 'DEFAULT'
+    | 'CLIENT'
+    | 'OFF_VARIATION'
+    | 'PREREQUISITE'
 }

--- a/src/BKTExceptions.ts
+++ b/src/BKTExceptions.ts
@@ -1,4 +1,7 @@
-import { ErrorMetricsEventType, MetricsEventType } from './internal/model/MetricsEventData'
+import {
+  ErrorMetricsEventType,
+  MetricsEventType,
+} from './internal/model/MetricsEventData'
 
 abstract class BKTBaseException extends Error {
   type?: ErrorMetricsEventType = undefined
@@ -39,7 +42,6 @@ export class ServiceUnavailableException extends BKTBaseException {
   type?: ErrorMetricsEventType = MetricsEventType.ServiceUnavailableError
 }
 
-
 // network errors
 export class TimeoutException extends BKTBaseException {
   type?: ErrorMetricsEventType = MetricsEventType.TimeoutError
@@ -55,4 +57,16 @@ export class IllegalStateException extends BKTBaseException {}
 // unknown errors
 export class UnknownException extends BKTBaseException {}
 
-export type BKTException = BadRequestException | UnauthorizedException | ForbiddenException | NotFoundException | ClientClosedRequestException | InternalServerErrorException | ServiceUnavailableException | TimeoutException | NetworkException | IllegalArgumentException | IllegalStateException | UnknownException
+export type BKTException =
+  | BadRequestException
+  | UnauthorizedException
+  | ForbiddenException
+  | NotFoundException
+  | ClientClosedRequestException
+  | InternalServerErrorException
+  | ServiceUnavailableException
+  | TimeoutException
+  | NetworkException
+  | IllegalArgumentException
+  | IllegalStateException
+  | UnknownException

--- a/src/BKTUser.ts
+++ b/src/BKTUser.ts
@@ -8,7 +8,6 @@ export interface BKTUser extends RawBKTUser {
   readonly attributes: Record<string, string>
 }
 
-
 export const defineBKTUser = (user: RawBKTUser): BKTUser => {
   if (!user.id) {
     throw new Error('user id is required')
@@ -17,7 +16,7 @@ export const defineBKTUser = (user: RawBKTUser): BKTUser => {
   return {
     id: user.id,
     attributes: {
-      ...user.customAttributes
-    }
+      ...user.customAttributes,
+    },
   }
 }

--- a/src/internal/IdGenerator.ts
+++ b/src/internal/IdGenerator.ts
@@ -1,4 +1,3 @@
-
 export interface IdGenerator {
   newId(): string
 }

--- a/src/internal/UserHolder.ts
+++ b/src/internal/UserHolder.ts
@@ -5,9 +5,7 @@ export class UserHolder {
   private user: User
   userId: string
 
-  constructor(
-    user: User,
-  ) {
+  constructor(user: User) {
     this.user = user
     this.userId = this.user.id
   }
@@ -16,7 +14,9 @@ export class UserHolder {
     return this.user
   }
 
-  updateAttributes(updater: (previous: Record<string, string>) => Record<string, string>): void {
+  updateAttributes(
+    updater: (previous: Record<string, string>) => Record<string, string>,
+  ): void {
     this.user = {
       ...this.user,
       data: updater(this.user.data ?? {}),

--- a/src/internal/di/Component.ts
+++ b/src/internal/di/Component.ts
@@ -33,7 +33,7 @@ export class DefaultComponent implements Component {
       this._evaluationInteractor = this.interactorModule.evaluationInteractor(
         this.dataModule.apiClient(),
         this.dataModule.evaluationStorage(),
-        this.dataModule.idGenerator()
+        this.dataModule.idGenerator(),
       )
     }
     return this._evaluationInteractor

--- a/src/internal/di/DataModule.ts
+++ b/src/internal/di/DataModule.ts
@@ -1,6 +1,9 @@
 import { BKTConfig } from '../../BKTConfig'
 import { Clock, DefaultClock } from '../Clock'
-import { EvaluationStorage, EvaluationStorageImpl } from '../evaluation/EvaluationStorage'
+import {
+  EvaluationStorage,
+  EvaluationStorageImpl,
+} from '../evaluation/EvaluationStorage'
 import { EventStorage, EventStorageImpl } from '../event/EventStorage'
 import { DefaultIdGenerator, IdGenerator } from '../IdGenerator'
 import { User } from '../model/User'
@@ -17,10 +20,7 @@ export class DataModule {
   private _evaluationStorage?: EvaluationStorage
   private _eventStorage?: EventStorage
 
-  constructor(
-    user: User,
-    config: BKTConfig,
-  ) {
+  constructor(user: User, config: BKTConfig) {
     this._config = config
     this._userHolder = new UserHolder(user)
   }
@@ -64,7 +64,7 @@ export class DataModule {
     if (!this._evaluationStorage) {
       this._evaluationStorage = new EvaluationStorageImpl(
         this.userHolder().userId,
-        new DefaultStorage(`${this.config().storageKeyPrefix}_bkt_evaluations`)
+        new DefaultStorage(`${this.config().storageKeyPrefix}_bkt_evaluations`),
       )
     }
     return this._evaluationStorage
@@ -74,7 +74,7 @@ export class DataModule {
     if (!this._eventStorage) {
       this._eventStorage = new EventStorageImpl(
         this.userHolder().userId,
-        new DefaultStorage(`${this.config().storageKeyPrefix}_bkt_events`)
+        new DefaultStorage(`${this.config().storageKeyPrefix}_bkt_events`),
       )
     }
     return this._eventStorage

--- a/src/internal/di/InteractorModule.ts
+++ b/src/internal/di/InteractorModule.ts
@@ -12,11 +12,7 @@ export class InteractorModule {
     evaluationStorage: EvaluationStorage,
     idGenerator: IdGenerator,
   ): EvaluationInteractor {
-    return new EvaluationInteractor(
-      apiClient,
-      evaluationStorage,
-      idGenerator,
-    )
+    return new EvaluationInteractor(apiClient, evaluationStorage, idGenerator)
   }
 
   eventInteractor(

--- a/src/internal/evaluation/EvaluationInteractor.ts
+++ b/src/internal/evaluation/EvaluationInteractor.ts
@@ -10,15 +10,23 @@ export class EvaluationInteractor {
     private apiClient: ApiClient,
     private evaluationStorage: EvaluationStorage,
     private idGenerator: IdGenerator,
-  ) { }
+  ) {}
 
   // visible for testing. should only be accessed from test code
   updateListeners: Record<string, () => void> = {}
 
-  async fetch(user: User, timeoutMillis?: number): Promise<GetEvaluationsResult> {
-    const currentEvaluationsId = this.evaluationStorage.getCurrentEvaluationsId() ?? ''
+  async fetch(
+    user: User,
+    timeoutMillis?: number,
+  ): Promise<GetEvaluationsResult> {
+    const currentEvaluationsId =
+      this.evaluationStorage.getCurrentEvaluationsId() ?? ''
 
-    const result = await this.apiClient.getEvaluations(user, currentEvaluationsId, timeoutMillis)
+    const result = await this.apiClient.getEvaluations(
+      user,
+      currentEvaluationsId,
+      timeoutMillis,
+    )
 
     if (result.type === 'success') {
       const response = result.value
@@ -31,10 +39,10 @@ export class EvaluationInteractor {
 
       this.evaluationStorage.deleteAllAndInsert(
         response.userEvaluationsId,
-        response.evaluations.evaluations ?? []
+        response.evaluations.evaluations ?? [],
       )
 
-      Object.values(this.updateListeners).forEach(listener => listener())
+      Object.values(this.updateListeners).forEach((listener) => listener())
     }
 
     return result

--- a/src/internal/evaluation/EvaluationStorage.ts
+++ b/src/internal/evaluation/EvaluationStorage.ts
@@ -4,7 +4,7 @@ import { BKTStorage } from '../storege'
 export interface EvaluationEntity {
   userId: string
   currentEvaluationsId: string | null
-  evaluations: Record<string/* featureId */, Evaluation>
+  evaluations: Record<string /* featureId */, Evaluation>
 }
 
 export interface EvaluationStorage {
@@ -15,11 +15,10 @@ export interface EvaluationStorage {
 }
 
 export class EvaluationStorageImpl implements EvaluationStorage {
-
   constructor(
     public userId: string,
-    public storage: BKTStorage<EvaluationEntity>
-  ) { }
+    public storage: BKTStorage<EvaluationEntity>,
+  ) {}
 
   getByFeatureId(featureId: string): Evaluation | null {
     const entity = this.getInternal(this.userId)
@@ -30,9 +29,12 @@ export class EvaluationStorageImpl implements EvaluationStorage {
     const entity: EvaluationEntity = {
       userId: this.userId,
       currentEvaluationsId: evaluationsId,
-      evaluations: evaluations.reduce<EvaluationEntity['evaluations']>((acc, cur) => {
-        return {...acc, [cur.featureId]: cur}
-      }, {})
+      evaluations: evaluations.reduce<EvaluationEntity['evaluations']>(
+        (acc, cur) => {
+          return { ...acc, [cur.featureId]: cur }
+        },
+        {},
+      ),
     }
 
     this.storage.set(entity)
@@ -53,7 +55,7 @@ export class EvaluationStorageImpl implements EvaluationStorage {
       return {
         userId,
         currentEvaluationsId: null,
-        evaluations: {}
+        evaluations: {},
       }
     }
     return entity

--- a/src/internal/event/EventCreators.ts
+++ b/src/internal/event/EventCreators.ts
@@ -1,11 +1,23 @@
-import { EvaluationEvent, GoalEvent, MetricsEvent, BaseEvent } from '../model/Event'
-import { ApiId, ErrorMetricsEventType, LatencyMetricsEvent, MetricsEventData, MetricsEventType, SizeMetricsEvent } from '../model/MetricsEventData'
+import {
+  EvaluationEvent,
+  GoalEvent,
+  MetricsEvent,
+  BaseEvent,
+} from '../model/Event'
+import {
+  ApiId,
+  ErrorMetricsEventType,
+  LatencyMetricsEvent,
+  MetricsEventData,
+  MetricsEventType,
+  SizeMetricsEvent,
+} from '../model/MetricsEventData'
 import { SourceID } from '../model/SourceID'
 
 export const newMetadata = (
   appVersion: string,
   osVersion: string,
-  deviceModel: string
+  deviceModel: string,
 ): Record<string, string> => {
   return {
     appVersion,
@@ -16,47 +28,51 @@ export const newMetadata = (
 
 export const newBaseEvent = (
   timestamp: number,
-  metadata: Record<string, string>
+  metadata: Record<string, string>,
 ): BaseEvent => {
   return {
     timestamp,
     sourceId: SourceID.JAVASCRIPT,
     sdkVersion: __BKT_SDK_VERSION__,
-    metadata
+    metadata,
   }
 }
 
 export const newEvaluationEvent = (
   base: BaseEvent,
-  fields: Omit<EvaluationEvent, keyof BaseEvent>
+  fields: Omit<EvaluationEvent, keyof BaseEvent>,
 ): EvaluationEvent => {
   return {
     ...base,
-    ...fields
+    ...fields,
   }
 }
 
 export const newDefaultEvaluationEvent = (
   base: BaseEvent,
-  fields: Omit<EvaluationEvent, keyof BaseEvent>
+  fields: Omit<EvaluationEvent, keyof BaseEvent>,
 ): EvaluationEvent => {
   return {
     ...base,
-    ...fields
+    ...fields,
   }
 }
 
 export const newGoalEvent = (
   base: BaseEvent,
-  fields: Omit<GoalEvent, keyof BaseEvent>
+  fields: Omit<GoalEvent, keyof BaseEvent>,
 ): GoalEvent => {
   return {
     ...base,
-    ...fields
+    ...fields,
   }
 }
 
-export const newLatencyMetricsData = (apiId: ApiId, duration: number, featureTag: string): LatencyMetricsEvent => {
+export const newLatencyMetricsData = (
+  apiId: ApiId,
+  duration: number,
+  featureTag: string,
+): LatencyMetricsEvent => {
   return {
     apiId,
     labels: { tag: featureTag },
@@ -65,7 +81,11 @@ export const newLatencyMetricsData = (apiId: ApiId, duration: number, featureTag
   }
 }
 
-export const newSizeMetricsData = (apiId: ApiId, sizeByte: number, featureTag: string): SizeMetricsEvent => {
+export const newSizeMetricsData = (
+  apiId: ApiId,
+  sizeByte: number,
+  featureTag: string,
+): SizeMetricsEvent => {
   return {
     apiId,
     labels: { tag: featureTag },
@@ -74,7 +94,11 @@ export const newSizeMetricsData = (apiId: ApiId, sizeByte: number, featureTag: s
   }
 }
 
-export const newErrorMetricsData = (apiId: ApiId, type: ErrorMetricsEventType, featureTag: string): MetricsEventData => {
+export const newErrorMetricsData = (
+  apiId: ApiId,
+  type: ErrorMetricsEventType,
+  featureTag: string,
+): MetricsEventData => {
   return {
     apiId,
     labels: { tag: featureTag },
@@ -83,11 +107,11 @@ export const newErrorMetricsData = (apiId: ApiId, type: ErrorMetricsEventType, f
 }
 
 export const newMetricsEvent = (
-  base:BaseEvent,
-  fields: Omit<MetricsEvent, keyof BaseEvent>
+  base: BaseEvent,
+  fields: Omit<MetricsEvent, keyof BaseEvent>,
 ): MetricsEvent => {
   return {
     ...base,
-    ...fields
+    ...fields,
   }
 }

--- a/src/internal/event/EventStorage.ts
+++ b/src/internal/event/EventStorage.ts
@@ -11,14 +11,11 @@ export interface EventStorage {
   add(event: Event): void
   addAll(events: Event[]): void
   deleteByIds(ids: string[]): void
-  clear():void
+  clear(): void
 }
 
 export class EventStorageImpl implements EventStorage {
-  constructor(
-    public userId: string,
-    public storage: BKTStorage<EventEntity>
-  ) { }
+  constructor(public userId: string, public storage: BKTStorage<EventEntity>) {}
 
   add(event: Event): void {
     const entity = this.getInternal(this.userId)
@@ -38,7 +35,7 @@ export class EventStorageImpl implements EventStorage {
 
   deleteByIds(ids: string[]): void {
     const entity = this.getInternal(this.userId)
-    entity.events = entity.events.filter(e => !ids.includes(e.id))
+    entity.events = entity.events.filter((e) => !ids.includes(e.id))
     this.storage.set(entity)
   }
 
@@ -52,7 +49,7 @@ export class EventStorageImpl implements EventStorage {
       // entity doesn't exist or userId is different
       return {
         userId,
-        events: []
+        events: [],
       }
     }
     return entity

--- a/src/internal/model/Event.ts
+++ b/src/internal/model/Event.ts
@@ -9,7 +9,7 @@ export const EventType = {
   EVALUATION: 3,
   METRICS: 4,
 } as const
-export type EventType = typeof EventType[keyof typeof EventType]
+export type EventType = (typeof EventType)[keyof typeof EventType]
 
 export interface BaseEvent {
   timestamp: number
@@ -43,17 +43,17 @@ export interface MetricsEvent extends BaseEvent {
 export type Event =
   | {
       id: string
-      type: typeof EventType['GOAL']
+      type: (typeof EventType)['GOAL']
       event: GoalEvent
     }
   // type: 2 is not for client
   | {
       id: string
-      type: typeof EventType['EVALUATION']
+      type: (typeof EventType)['EVALUATION']
       event: EvaluationEvent
     }
   | {
       id: string
-      type: typeof EventType['METRICS']
+      type: (typeof EventType)['METRICS']
       event: MetricsEvent
     }

--- a/src/internal/model/MetricsEventData.ts
+++ b/src/internal/model/MetricsEventData.ts
@@ -4,112 +4,142 @@ export const ApiId = {
   GET_EVALUATIONS: 2,
   REGISTER_EVENTS: 3,
 } as const
-export type ApiId = typeof ApiId[keyof typeof ApiId]
+export type ApiId = (typeof ApiId)[keyof typeof ApiId]
 
 export const MetricsEventType = {
-  LatencyMetrics: 'type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent',
+  LatencyMetrics:
+    'type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent',
   SizeMetrics: 'type.googleapis.com/bucketeer.event.client.SizeMetricsEvent',
-  BadRequestError: 'type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent',
-  UnauthorizedError: 'type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent',
-  ForbiddenError: 'type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent',
-  NotFoundError: 'type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent',
-  ClientClosedRequestError: 'type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent',
-  InternalServerError: 'type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent',
-  ServiceUnavailableError: 'type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent',
-  InternalSdkError: 'type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent',
-  TimeoutError: 'type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent',
-  NetworkError: 'type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent',
-  UnknownError: 'type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent',
+  BadRequestError:
+    'type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent',
+  UnauthorizedError:
+    'type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent',
+  ForbiddenError:
+    'type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent',
+  NotFoundError:
+    'type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent',
+  ClientClosedRequestError:
+    'type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent',
+  InternalServerError:
+    'type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent',
+  ServiceUnavailableError:
+    'type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent',
+  InternalSdkError:
+    'type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent',
+  TimeoutError:
+    'type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent',
+  NetworkError:
+    'type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent',
+  UnknownError:
+    'type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent',
 } as const
-export type MetricsEventType = typeof MetricsEventType[keyof typeof MetricsEventType]
+export type MetricsEventType =
+  (typeof MetricsEventType)[keyof typeof MetricsEventType]
 
-export type ErrorMetricsEventType = Exclude<MetricsEventType, typeof MetricsEventType['LatencyMetrics'] | typeof MetricsEventType['SizeMetrics']>
+export type ErrorMetricsEventType = Exclude<
+  MetricsEventType,
+  | (typeof MetricsEventType)['LatencyMetrics']
+  | (typeof MetricsEventType)['SizeMetrics']
+>
 
 export interface LatencyMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
   duration: number
-  '@type': typeof MetricsEventType['LatencyMetrics']
+  '@type': (typeof MetricsEventType)['LatencyMetrics']
 }
 
 export interface SizeMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
   sizeByte: number
-  '@type': typeof MetricsEventType['SizeMetrics']
+  '@type': (typeof MetricsEventType)['SizeMetrics']
 }
 
 // 400: Bad Request
 export interface BadRequestErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['BadRequestError']
+  '@type': (typeof MetricsEventType)['BadRequestError']
 }
 
 // 401: Unauthorized
 export interface UnauthorizedErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['UnauthorizedError']
+  '@type': (typeof MetricsEventType)['UnauthorizedError']
 }
 
 // 403: Forbidden
 export interface ForbiddenErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['ForbiddenError']
+  '@type': (typeof MetricsEventType)['ForbiddenError']
 }
 
 // 404: NotFound
 export interface NotFoundErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['NotFoundError']
+  '@type': (typeof MetricsEventType)['NotFoundError']
 }
 
 // 499: Client Closed Request
 export interface ClientClosedRequestMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['ClientClosedRequestError']
+  '@type': (typeof MetricsEventType)['ClientClosedRequestError']
 }
 
 // 500: Internal Server Error
 export interface InternalServerErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['InternalServerError']
+  '@type': (typeof MetricsEventType)['InternalServerError']
 }
 
 // 503: Service Unavailable
 export interface ServiceUnavailableErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['ServiceUnavailableError']
+  '@type': (typeof MetricsEventType)['ServiceUnavailableError']
 }
 
 export interface TimeoutErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['TimeoutError']
+  '@type': (typeof MetricsEventType)['TimeoutError']
 }
 
 export interface NetworkErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['NetworkError']
+  '@type': (typeof MetricsEventType)['NetworkError']
 }
 
 export interface InternalSdkErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['InternalSdkError']
+  '@type': (typeof MetricsEventType)['InternalSdkError']
 }
 
 export interface UnknownErrorMetricsEvent {
   apiId: ApiId
   labels: Record<string, string>
-  '@type': typeof MetricsEventType['UnknownError']
+  '@type': (typeof MetricsEventType)['UnknownError']
 }
 
-export type MetricsEventData = LatencyMetricsEvent | SizeMetricsEvent | BadRequestErrorMetricsEvent | UnauthorizedErrorMetricsEvent | ForbiddenErrorMetricsEvent | NotFoundErrorMetricsEvent | ClientClosedRequestMetricsEvent | InternalServerErrorMetricsEvent | ServiceUnavailableErrorMetricsEvent | TimeoutErrorMetricsEvent | NetworkErrorMetricsEvent | InternalSdkErrorMetricsEvent | UnknownErrorMetricsEvent
+export type MetricsEventData =
+  | LatencyMetricsEvent
+  | SizeMetricsEvent
+  | BadRequestErrorMetricsEvent
+  | UnauthorizedErrorMetricsEvent
+  | ForbiddenErrorMetricsEvent
+  | NotFoundErrorMetricsEvent
+  | ClientClosedRequestMetricsEvent
+  | InternalServerErrorMetricsEvent
+  | ServiceUnavailableErrorMetricsEvent
+  | TimeoutErrorMetricsEvent
+  | NetworkErrorMetricsEvent
+  | InternalSdkErrorMetricsEvent
+  | UnknownErrorMetricsEvent

--- a/src/internal/model/Reason.ts
+++ b/src/internal/model/Reason.ts
@@ -1,8 +1,14 @@
-const ReasonTypeValue = ['TARGET', 'RULE', 'DEFAULT', 'CLIENT', 'OFF_VARIATION', 'PREREQUISITE'] as const
+const ReasonTypeValue = [
+  'TARGET',
+  'RULE',
+  'DEFAULT',
+  'CLIENT',
+  'OFF_VARIATION',
+  'PREREQUISITE',
+] as const
 export type ReasonType = (typeof ReasonTypeValue)[number]
 
 export interface Reason {
   type: ReasonType
   ruleId?: string
 }
-

--- a/src/internal/model/SourceID.ts
+++ b/src/internal/model/SourceID.ts
@@ -9,4 +9,4 @@ export const SourceID = {
   JAVASCRIPT: 7,
 } as const
 
-export type SourceID = typeof SourceID[keyof typeof SourceID]
+export type SourceID = (typeof SourceID)[keyof typeof SourceID]

--- a/src/internal/remote/ApiClient.ts
+++ b/src/internal/remote/ApiClient.ts
@@ -5,41 +5,46 @@ import { SourceID } from '../model/SourceID'
 import { User } from '../model/User'
 import { FetchLike, FetchRequestLike } from './fetch'
 import { postInternal } from './post'
-import { GetEvaluationsFailure, GetEvaluationsResult, GetEvaluationsSuccess } from './GetEvaluationsResult'
+import {
+  GetEvaluationsFailure,
+  GetEvaluationsResult,
+  GetEvaluationsSuccess,
+} from './GetEvaluationsResult'
 import { Event } from '../model/Event'
 import { RegisterEventsResult } from './RegisterEventsResult'
 import { RegisterEventsRequest } from '../model/request/RegisterEventsRequest'
 import { RegisterEventsResponse } from '../model/response/RegisterEventsResponse'
 
 export interface ApiClient {
-  getEvaluations(user: User, userEvaluationsId: string, timeoutMillis?: number): Promise<GetEvaluationsResult>
+  getEvaluations(
+    user: User,
+    userEvaluationsId: string,
+    timeoutMillis?: number,
+  ): Promise<GetEvaluationsResult>
   registerEvents(events: Event[]): Promise<RegisterEventsResult>
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MILLIS = 30_000
 
 export class ApiClientImpl implements ApiClient {
-
   constructor(
     private readonly endpoint: string,
     private readonly apiKey: string,
     private readonly featureTag: string,
     private readonly fetch: FetchLike,
     private readonly defaultRequestTimeoutMillis: number = DEFAULT_REQUEST_TIMEOUT_MILLIS,
-  ) {
-
-  }
+  ) {}
 
   async getEvaluations(
     user: User,
     userEvaluationsId: string,
-    timeoutMillis: number = this.defaultRequestTimeoutMillis
+    timeoutMillis: number = this.defaultRequestTimeoutMillis,
   ): Promise<GetEvaluationsResult> {
     const body: GetEvaluationsRequest = {
       tag: this.featureTag,
       user,
       userEvaluationsId: userEvaluationsId,
-      sourceId: SourceID.JAVASCRIPT
+      sourceId: SourceID.JAVASCRIPT,
     }
 
     try {
@@ -50,14 +55,14 @@ export class ApiClientImpl implements ApiClient {
         this.createHeaders(),
         body,
         this.fetch,
-        timeoutMillis
+        timeoutMillis,
       )
 
       const finish = Date.now()
 
       // all non-ok status code is already converted to BKTException,
       // so we can assume that the status code is 200 here.
-      const contentLength = (() =>{
+      const contentLength = (() => {
         const value = res.headers.get('Content-Length')
         if (value) {
           return Number(value)
@@ -71,9 +76,8 @@ export class ApiClientImpl implements ApiClient {
         sizeByte: contentLength,
         seconds: (finish - start) / 1000,
         featureTag: this.featureTag,
-        value: await res.json() as GetEvaluationsResponse
+        value: (await res.json()) as GetEvaluationsResponse,
       } satisfies GetEvaluationsSuccess
-
     } catch (e) {
       return {
         type: 'failure',
@@ -92,14 +96,14 @@ export class ApiClientImpl implements ApiClient {
         this.createHeaders(),
         body,
         this.fetch,
-        this.defaultRequestTimeoutMillis
+        this.defaultRequestTimeoutMillis,
       )
 
       // all non-ok status code is already converted to BKTException,
       // so we can assume that the status code is 200 here.
       return {
         type: 'success',
-        value: await res.json() as RegisterEventsResponse
+        value: (await res.json()) as RegisterEventsResponse,
       } satisfies RegisterEventsResult
     } catch (e) {
       return {
@@ -112,7 +116,7 @@ export class ApiClientImpl implements ApiClient {
   private createHeaders(): FetchRequestLike['headers'] {
     return {
       'Content-Type': 'application/json',
-      'Authorization': this.apiKey,
+      Authorization: this.apiKey,
     }
   }
 }

--- a/src/internal/remote/fetch.ts
+++ b/src/internal/remote/fetch.ts
@@ -20,5 +20,5 @@ export type FetchResponseLike = {
 
 export type FetchLike = (
   url: string,
-  request: FetchRequestLike
+  request: FetchRequestLike,
 ) => Promise<FetchResponseLike>

--- a/src/internal/remote/post.ts
+++ b/src/internal/remote/post.ts
@@ -26,7 +26,7 @@ export const postInternal = async (
       if (e.name === 'AbortError') {
         throw new TimeoutException('Timeout Error')
       } else {
-      // convert network error to NetworkException
+        // convert network error to NetworkException
         throw new NetworkException(`Network Error: ${e.message}`)
       }
     })

--- a/src/internal/remote/toBKTException.ts
+++ b/src/internal/remote/toBKTException.ts
@@ -1,27 +1,49 @@
-import { BadRequestException, BKTException, ClientClosedRequestException, ForbiddenException, InternalServerErrorException, NotFoundException, ServiceUnavailableException, UnauthorizedException, UnknownException } from '../../BKTExceptions'
+import {
+  BadRequestException,
+  BKTException,
+  ClientClosedRequestException,
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+  UnknownException,
+} from '../../BKTExceptions'
 import { ErrorResponse } from '../model/response/ErrorResponse'
 import { FetchResponseLike } from './fetch'
 
-export const toBKTException = async (response: FetchResponseLike): Promise<BKTException> => {
+export const toBKTException = async (
+  response: FetchResponseLike,
+): Promise<BKTException> => {
   const errorBody: ErrorResponse | null = await response.json()
   const error = errorBody?.error
 
   switch (response.status) {
-  case 400:
-    return new BadRequestException(error?.message ?? 'Bad Request')
-  case 401:
-    return new UnauthorizedException(error?.message ?? 'Unauthorized')
-  case 403:
-    return new ForbiddenException(error?.message ?? 'Forbidden')
-  case 404:
-    return new NotFoundException(error?.message ?? 'Feature Not Found')
-  case 499:
-    return new ClientClosedRequestException(error?.message ?? 'Client Closed Request')
-  case 500:
-    return new InternalServerErrorException(error?.message ?? 'Internal Server Error')
-  case 503:
-    return new ServiceUnavailableException(error?.message ?? 'Service Unavailable')
-  default:
-    return new UnknownException(`Unknown Error: ${response.status} ${response.statusText}, ${JSON.stringify(errorBody)}`)
+    case 400:
+      return new BadRequestException(error?.message ?? 'Bad Request')
+    case 401:
+      return new UnauthorizedException(error?.message ?? 'Unauthorized')
+    case 403:
+      return new ForbiddenException(error?.message ?? 'Forbidden')
+    case 404:
+      return new NotFoundException(error?.message ?? 'Feature Not Found')
+    case 499:
+      return new ClientClosedRequestException(
+        error?.message ?? 'Client Closed Request',
+      )
+    case 500:
+      return new InternalServerErrorException(
+        error?.message ?? 'Internal Server Error',
+      )
+    case 503:
+      return new ServiceUnavailableException(
+        error?.message ?? 'Service Unavailable',
+      )
+    default:
+      return new UnknownException(
+        `Unknown Error: ${response.status} ${
+          response.statusText
+        }, ${JSON.stringify(errorBody)}`,
+      )
   }
 }

--- a/src/internal/storege/index.ts
+++ b/src/internal/storege/index.ts
@@ -1,5 +1,5 @@
-
-export const keyname = (prefix: string, key: string): string => `${prefix}_${key}`
+export const keyname = (prefix: string, key: string): string =>
+  `${prefix}_${key}`
 
 export interface BKTStorage<T> {
   set(value: T | null): void
@@ -8,10 +8,7 @@ export interface BKTStorage<T> {
 }
 
 export class DefaultStorage<T> implements BKTStorage<T> {
-
-  constructor(
-    private key: string
-  ) { }
+  constructor(private key: string) {}
 
   public set<T>(value: T | null) {
     localStorage.setItem(this.key, JSON.stringify(value))

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test,expect } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import { defineBKTConfig } from '../src/BKTConfig'
 
 const defaultConfig: Parameters<typeof defineBKTConfig>[0] = {
@@ -10,10 +10,9 @@ const defaultConfig: Parameters<typeof defineBKTConfig>[0] = {
 }
 
 describe('defineBKTConfig', () => {
-
   test('all parameters are valid', () => {
     const result = defineBKTConfig({
-      ...defaultConfig
+      ...defaultConfig,
     })
 
     expect(result).toStrictEqual({
@@ -38,7 +37,7 @@ describe('defineBKTConfig', () => {
     expect(() => {
       defineBKTConfig({
         ...defaultConfig,
-        apiEndpoint: ''
+        apiEndpoint: '',
       })
     }).toThrowError('apiEndpoint is required')
   })
@@ -47,7 +46,7 @@ describe('defineBKTConfig', () => {
     expect(() => {
       defineBKTConfig({
         ...defaultConfig,
-        apiEndpoint: 'not a valid url'
+        apiEndpoint: 'not a valid url',
       })
     }).toThrowError('apiEndpoint is invalid')
   })
@@ -65,7 +64,7 @@ describe('defineBKTConfig', () => {
     expect(() => {
       defineBKTConfig({
         ...defaultConfig,
-        appVersion: ''
+        appVersion: '',
       })
     }).toThrowError('appVersion is required')
   })
@@ -73,7 +72,7 @@ describe('defineBKTConfig', () => {
   test('sooner eventFlushInterval should be replaced with default value', () => {
     const result = defineBKTConfig({
       ...defaultConfig,
-      eventsFlushInterval: 10
+      eventsFlushInterval: 10,
     })
 
     expect(result.eventsFlushInterval).toBe(60_000)
@@ -82,7 +81,7 @@ describe('defineBKTConfig', () => {
   test('sooner pollingInterval should be replaced with default value', () => {
     const result = defineBKTConfig({
       ...defaultConfig,
-      pollingInterval: 10
+      pollingInterval: 10,
     })
 
     expect(result.pollingInterval).toBe(600_000)

--- a/test/BKTUser.spec.ts
+++ b/test/BKTUser.spec.ts
@@ -7,14 +7,14 @@ describe('defineBKTUser', () => {
       id: 'user-id',
       customAttributes: {
         'key-1': 'value-1',
-      }
+      },
     })
 
     expect(result).toStrictEqual({
       id: 'user-id',
       attributes: {
         'key-1': 'value-1',
-      }
+      },
     })
   })
 
@@ -28,7 +28,8 @@ describe('defineBKTUser', () => {
 
   test('calling without customAttributes results in empty attributes', () => {
     const result = defineBKTUser({
-      id: 'user-id',})
+      id: 'user-id',
+    })
 
     expect(result).toStrictEqual({
       id: 'user-id',

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'node:crypto'
 
-
 // setup crypto.randomUUID
 Object.defineProperty(global.self, 'crypto', {
   value: {
-    randomUUID: randomUUID
-  }
+    randomUUID: randomUUID,
+  },
 })

--- a/test/internal/evaluation/EvaluationInteractor.spec.ts
+++ b/test/internal/evaluation/EvaluationInteractor.spec.ts
@@ -11,7 +11,12 @@ import { user1 } from '../../mocks/users'
 import { EvaluationInteractor } from '../../../src/internal/evaluation/EvaluationInteractor'
 import { GetEvaluationsRequest } from '../../../src/internal/model/request/GetEvaluationsRequest'
 import { GetEvaluationsResponse } from '../../../src/internal/model/response/GetEvaluationsResponse'
-import { evaluation1, evaluation2, evaluation3, user1Evaluations } from '../../mocks/evaluations'
+import {
+  evaluation1,
+  evaluation2,
+  evaluation3,
+  user1Evaluations,
+} from '../../mocks/evaluations'
 import { EvaluationStorageImpl } from '../../../src/internal/evaluation/EvaluationStorage'
 import { setupServerAndListen } from '../../utils'
 
@@ -31,13 +36,14 @@ suite('internal/evaluation/EvaluationInteractor', () => {
           featureTag: 'feature_tag_value',
           appVersion: '1.2.3',
           fetch,
-        })
+        }),
       ),
-      new InteractorModule()
+      new InteractorModule(),
     )
 
     interactor = component.evaluationInteractor()
-    evaluationStorage = component.dataModule.evaluationStorage() as EvaluationStorageImpl
+    evaluationStorage =
+      component.dataModule.evaluationStorage() as EvaluationStorageImpl
   })
 
   afterEach(() => {
@@ -48,7 +54,11 @@ suite('internal/evaluation/EvaluationInteractor', () => {
   suite('fetch', () => {
     test('initial load', async () => {
       server = setupServerAndListen(
-        rest.post<GetEvaluationsRequest, Record<string, never>, GetEvaluationsResponse>(
+        rest.post<
+          GetEvaluationsRequest,
+          Record<string, never>,
+          GetEvaluationsResponse
+        >(
           'https://api.bucketeer.io/get_evaluations',
           async (_req, res, ctx) => {
             return res(
@@ -56,12 +66,15 @@ suite('internal/evaluation/EvaluationInteractor', () => {
               ctx.json({
                 evaluations: user1Evaluations,
                 userEvaluationsId: 'user_evaluation_id_value',
-              })
+              }),
             )
-          })
+          },
+        ),
       )
 
-      expect(component.dataModule.evaluationStorage().getCurrentEvaluationsId()).toBeNull()
+      expect(
+        component.dataModule.evaluationStorage().getCurrentEvaluationsId(),
+      ).toBeNull()
 
       const mockListener = vi.fn<[], void>()
       interactor.addUpdateListener(mockListener)
@@ -77,22 +90,25 @@ suite('internal/evaluation/EvaluationInteractor', () => {
         currentEvaluationsId: 'user_evaluation_id_value',
         evaluations: {
           [evaluation1.featureId]: evaluation1,
-          [evaluation2.featureId]: evaluation2
-        }
+          [evaluation2.featureId]: evaluation2,
+        },
       })
 
       expect(mockListener).toBeCalledTimes(1)
     })
 
     test('update', async () => {
-
       const newEvaluation = {
         ...evaluation1,
-        variationValue: 'new_variation_value'
+        variationValue: 'new_variation_value',
       }
       server = setupServerAndListen(
         // initial request
-        rest.post<GetEvaluationsRequest, Record<string, never>, GetEvaluationsResponse>(
+        rest.post<
+          GetEvaluationsRequest,
+          Record<string, never>,
+          GetEvaluationsResponse
+        >(
           'https://api.bucketeer.io/get_evaluations',
           async (_req, res, ctx) => {
             return res.once(
@@ -100,11 +116,16 @@ suite('internal/evaluation/EvaluationInteractor', () => {
               ctx.json({
                 evaluations: user1Evaluations,
                 userEvaluationsId: 'user_evaluation_id_value',
-              })
+              }),
             )
-          }),
+          },
+        ),
         // second request
-        rest.post<GetEvaluationsRequest, Record<string, never>, GetEvaluationsResponse>(
+        rest.post<
+          GetEvaluationsRequest,
+          Record<string, never>,
+          GetEvaluationsResponse
+        >(
           'https://api.bucketeer.io/get_evaluations',
           async (_req, res, ctx) => {
             return res.once(
@@ -112,12 +133,13 @@ suite('internal/evaluation/EvaluationInteractor', () => {
               ctx.json({
                 evaluations: {
                   ...user1Evaluations,
-                  evaluations: [newEvaluation]
+                  evaluations: [newEvaluation],
                 },
                 userEvaluationsId: 'user_evaluation_id_value_updated',
-              })
+              }),
             )
-          })
+          },
+        ),
       )
 
       const mockListener = vi.fn<[], void>()
@@ -127,7 +149,9 @@ suite('internal/evaluation/EvaluationInteractor', () => {
       const result1 = await interactor.fetch(user1)
 
       assert(result1.type === 'success')
-      expect(evaluationStorage.getCurrentEvaluationsId()).toBe('user_evaluation_id_value')
+      expect(evaluationStorage.getCurrentEvaluationsId()).toBe(
+        'user_evaluation_id_value',
+      )
 
       // second request
       const result2 = await interactor.fetch(user1)
@@ -140,7 +164,7 @@ suite('internal/evaluation/EvaluationInteractor', () => {
         currentEvaluationsId: 'user_evaluation_id_value_updated',
         evaluations: {
           [newEvaluation.featureId]: newEvaluation,
-        }
+        },
       })
 
       expect(mockListener).toBeCalledTimes(2)
@@ -148,7 +172,11 @@ suite('internal/evaluation/EvaluationInteractor', () => {
 
     test('update with no change', async () => {
       server = setupServerAndListen(
-        rest.post<GetEvaluationsRequest, Record<string, never>, GetEvaluationsResponse>(
+        rest.post<
+          GetEvaluationsRequest,
+          Record<string, never>,
+          GetEvaluationsResponse
+        >(
           'https://api.bucketeer.io/get_evaluations',
           async (_req, res, ctx) => {
             return res(
@@ -156,9 +184,10 @@ suite('internal/evaluation/EvaluationInteractor', () => {
               ctx.json({
                 evaluations: user1Evaluations,
                 userEvaluationsId: 'user_evaluation_id_value',
-              })
+              }),
             )
-          })
+          },
+        ),
       )
 
       const mockListener = vi.fn<[], void>()
@@ -176,8 +205,8 @@ suite('internal/evaluation/EvaluationInteractor', () => {
         currentEvaluationsId: 'user_evaluation_id_value',
         evaluations: {
           [evaluation1.featureId]: evaluation1,
-          [evaluation2.featureId]: evaluation2
-        }
+          [evaluation2.featureId]: evaluation2,
+        },
       })
 
       expect(mockListener).toBeCalledTimes(1)
@@ -191,8 +220,8 @@ suite('internal/evaluation/EvaluationInteractor', () => {
         currentEvaluationsId: 'user_evaluation_id_value',
         evaluations: {
           [evaluation1.featureId]: evaluation1,
-          [evaluation2.featureId]: evaluation2
-        }
+          [evaluation2.featureId]: evaluation2,
+        },
       })
 
       const result = interactor.getLatest(evaluation1.featureId)
@@ -206,8 +235,8 @@ suite('internal/evaluation/EvaluationInteractor', () => {
         currentEvaluationsId: 'user_evaluation_id_value',
         evaluations: {
           [evaluation1.featureId]: evaluation1,
-          [evaluation2.featureId]: evaluation2
-        }
+          [evaluation2.featureId]: evaluation2,
+        },
       })
 
       const result = interactor.getLatest(evaluation3.featureId)
@@ -217,15 +246,23 @@ suite('internal/evaluation/EvaluationInteractor', () => {
   })
 
   test('addUpdateListener', () => {
-    const key1 = interactor.addUpdateListener(() => { /* empty */ })
-    const key2 = interactor.addUpdateListener(() => { /* empty */ })
+    const key1 = interactor.addUpdateListener(() => {
+      /* empty */
+    })
+    const key2 = interactor.addUpdateListener(() => {
+      /* empty */
+    })
 
     expect(Object.keys(interactor.updateListeners)).toEqual([key1, key2])
   })
 
   test('removeUpdateListener', () => {
-    const key1 = interactor.addUpdateListener(() => { /* empty */ })
-    const key2 = interactor.addUpdateListener(() => { /* empty */ })
+    const key1 = interactor.addUpdateListener(() => {
+      /* empty */
+    })
+    const key2 = interactor.addUpdateListener(() => {
+      /* empty */
+    })
 
     expect(Object.keys(interactor.updateListeners)).toEqual([key1, key2])
 
@@ -235,8 +272,12 @@ suite('internal/evaluation/EvaluationInteractor', () => {
   })
 
   test('clearUpdateListeners', () => {
-    interactor.addUpdateListener(() => { /* empty */ })
-    interactor.addUpdateListener(() => { /* empty */ })
+    interactor.addUpdateListener(() => {
+      /* empty */
+    })
+    interactor.addUpdateListener(() => {
+      /* empty */
+    })
 
     expect(Object.keys(interactor.updateListeners)).toHaveLength(2)
 

--- a/test/internal/evaluation/EvaluationStorage.spec.ts
+++ b/test/internal/evaluation/EvaluationStorage.spec.ts
@@ -1,10 +1,13 @@
 import { expect, suite, test, beforeEach, afterEach } from 'vitest'
-import { EvaluationEntity, EvaluationStorage, EvaluationStorageImpl } from '../../../src/internal/evaluation/EvaluationStorage'
+import {
+  EvaluationEntity,
+  EvaluationStorage,
+  EvaluationStorageImpl,
+} from '../../../src/internal/evaluation/EvaluationStorage'
 import { BKTStorage, DefaultStorage } from '../../../src/internal/storege'
 import { evaluation1, evaluation2, evaluation3 } from '../../mocks/evaluations'
 
 suite('internal/evaluation/EvaluationStorage', () => {
-
   let storage: BKTStorage<EvaluationEntity>
   let evaluationStorage: EvaluationStorage
 
@@ -25,7 +28,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
         evaluations: {
           [evaluation1.featureId]: evaluation1,
           [evaluation2.featureId]: evaluation2,
-        }
+        },
       })
 
       const result = evaluationStorage.getByFeatureId(evaluation1.featureId)
@@ -40,7 +43,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
         evaluations: {
           [evaluation1.featureId]: evaluation1,
           [evaluation2.featureId]: evaluation2,
-        }
+        },
       })
 
       const result = evaluationStorage.getByFeatureId('feature_id_3')
@@ -56,7 +59,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
       evaluations: {
         [evaluation1.featureId]: evaluation1,
         [evaluation2.featureId]: evaluation2,
-      }
+      },
     })
 
     evaluationStorage.deleteAllAndInsert('evaluatIons_id_2', [evaluation3])
@@ -66,7 +69,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
       currentEvaluationsId: 'evaluatIons_id_2',
       evaluations: {
         [evaluation3.featureId]: evaluation3,
-      }
+      },
     })
   })
 
@@ -78,7 +81,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
         evaluations: {
           [evaluation1.featureId]: evaluation1,
           [evaluation2.featureId]: evaluation2,
-        }
+        },
       })
 
       const result = evaluationStorage.getCurrentEvaluationsId()
@@ -96,7 +99,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
       storage.set({
         userId: 'user_id_1',
         currentEvaluationsId: null,
-        evaluations: {}
+        evaluations: {},
       })
 
       const result = evaluationStorage.getCurrentEvaluationsId()
@@ -108,7 +111,7 @@ suite('internal/evaluation/EvaluationStorage', () => {
       storage.set({
         userId: 'user_id_2',
         currentEvaluationsId: 'evaluations_id_1',
-        evaluations: {}
+        evaluations: {},
       })
 
       const result = evaluationStorage.getCurrentEvaluationsId()

--- a/test/internal/event/EventStorage.spec.ts
+++ b/test/internal/event/EventStorage.spec.ts
@@ -1,7 +1,15 @@
 import { expect, suite, test, beforeEach, afterEach } from 'vitest'
-import { EventEntity, EventStorage, EventStorageImpl } from '../../../src/internal/event/EventStorage'
+import {
+  EventEntity,
+  EventStorage,
+  EventStorageImpl,
+} from '../../../src/internal/event/EventStorage'
 import { BKTStorage, DefaultStorage } from '../../../src/internal/storege'
-import { evaluationEvent1, evaluationEvent2, goalEvent1 } from '../../mocks/events'
+import {
+  evaluationEvent1,
+  evaluationEvent2,
+  goalEvent1,
+} from '../../mocks/events'
 
 suite('internal/event/EventStorage', () => {
   let storage: BKTStorage<EventEntity>
@@ -20,24 +28,18 @@ suite('internal/event/EventStorage', () => {
     test('return events if saved data is present', () => {
       storage.set({
         userId: 'user_id_1',
-        events: [
-          evaluationEvent1,
-          goalEvent1
-        ]
+        events: [evaluationEvent1, goalEvent1],
       })
 
       const result = eventStorage.getAll()
 
-      expect(result).toStrictEqual([
-        evaluationEvent1,
-        goalEvent1,
-      ])
+      expect(result).toStrictEqual([evaluationEvent1, goalEvent1])
     })
 
     test('return empty array if saved data is not present', () => {
       storage.set({
         userId: 'user_id_1',
-        events: []
+        events: [],
       })
 
       const result = eventStorage.getAll()
@@ -50,14 +52,14 @@ suite('internal/event/EventStorage', () => {
     test('add event to storage', () => {
       storage.set({
         userId: 'user_id_1',
-        events: [goalEvent1]
+        events: [goalEvent1],
       })
 
       eventStorage.add(evaluationEvent1)
 
       expect(storage.get()?.events).toStrictEqual([
         goalEvent1,
-        evaluationEvent1
+        evaluationEvent1,
       ])
     })
   })
@@ -66,7 +68,7 @@ suite('internal/event/EventStorage', () => {
     test('add events to storage', () => {
       storage.set({
         userId: 'user_id_1',
-        events: [goalEvent1]
+        events: [goalEvent1],
       })
 
       eventStorage.addAll([evaluationEvent1, evaluationEvent2])
@@ -74,7 +76,7 @@ suite('internal/event/EventStorage', () => {
       expect(storage.get()?.events).toStrictEqual([
         goalEvent1,
         evaluationEvent1,
-        evaluationEvent2
+        evaluationEvent2,
       ])
     })
   })
@@ -83,18 +85,12 @@ suite('internal/event/EventStorage', () => {
     test('delete events by ids', () => {
       storage.set({
         userId: 'user_id_1',
-        events: [
-          evaluationEvent1,
-          evaluationEvent2,
-          goalEvent1
-        ]
+        events: [evaluationEvent1, evaluationEvent2, goalEvent1],
       })
 
       eventStorage.deleteByIds([evaluationEvent1.id, goalEvent1.id])
 
-      expect(storage.get()?.events).toStrictEqual([
-        evaluationEvent2
-      ])
+      expect(storage.get()?.events).toStrictEqual([evaluationEvent2])
     })
   })
 
@@ -102,11 +98,7 @@ suite('internal/event/EventStorage', () => {
     test('clear events', () => {
       storage.set({
         userId: 'user_id_1',
-        events: [
-          evaluationEvent1,
-          evaluationEvent2,
-          goalEvent1
-        ]
+        events: [evaluationEvent1, evaluationEvent2, goalEvent1],
       })
 
       eventStorage.clear()

--- a/test/internal/remote/ApiClient.spec.ts
+++ b/test/internal/remote/ApiClient.spec.ts
@@ -6,7 +6,10 @@ import { SetupServer } from 'msw/node'
 import { GetEvaluationsRequest } from '../../../src/internal/model/request/GetEvaluationsRequest'
 import { GetEvaluationsResponse } from '../../../src/internal/model/response/GetEvaluationsResponse'
 import { user1Evaluations } from '../../mocks/evaluations'
-import { ApiClient, ApiClientImpl } from '../../../src/internal/remote/ApiClient'
+import {
+  ApiClient,
+  ApiClientImpl,
+} from '../../../src/internal/remote/ApiClient'
 import { user1 } from '../../mocks/users'
 import { SourceID } from '../../../src/internal/model/SourceID'
 import { RegisterEventsRequest } from '../../../src/internal/model/request/RegisterEventsRequest'
@@ -23,7 +26,7 @@ suite('internal/remote/ApiClient', () => {
       'https://api.bucketeer.io',
       'api_key_value',
       'feature_tag_value',
-      fetch
+      fetch,
     )
   })
 
@@ -34,31 +37,36 @@ suite('internal/remote/ApiClient', () => {
   suite('getEvaluations', () => {
     test('success', async () => {
       server = setupServerAndListen(
-        rest.post<GetEvaluationsRequest, Record<string, never>, GetEvaluationsResponse>(
-          'https://api.bucketeer.io/get_evaluations',
-          async (req, res, ctx) => {
-            expect(req.headers.get('Authorization')).toBe('api_key_value')
+        rest.post<
+          GetEvaluationsRequest,
+          Record<string, never>,
+          GetEvaluationsResponse
+        >('https://api.bucketeer.io/get_evaluations', async (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('api_key_value')
 
-            const request = await req.json()
-            expect(request).toStrictEqual<GetEvaluationsRequest>({
-              tag: 'feature_tag_value',
-              user: user1,
-              userEvaluationsId: 'user_evaluation_id',
-              sourceId: SourceID.JAVASCRIPT,
-            })
-
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Length', '10'),
-              ctx.json({
-                evaluations: user1Evaluations,
-                userEvaluationsId: 'user_evaluation_id',
-              }),
-            )
+          const request = await req.json()
+          expect(request).toStrictEqual<GetEvaluationsRequest>({
+            tag: 'feature_tag_value',
+            user: user1,
+            userEvaluationsId: 'user_evaluation_id',
+            sourceId: SourceID.JAVASCRIPT,
           })
+
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Length', '10'),
+            ctx.json({
+              evaluations: user1Evaluations,
+              userEvaluationsId: 'user_evaluation_id',
+            }),
+          )
+        }),
       )
 
-      const response = await apiClient.getEvaluations(user1, 'user_evaluation_id')
+      const response = await apiClient.getEvaluations(
+        user1,
+        'user_evaluation_id',
+      )
 
       assert(response.type === 'success')
 
@@ -68,7 +76,7 @@ suite('internal/remote/ApiClient', () => {
       expect(response.featureTag).toBe('feature_tag_value')
       expect(response.value).toStrictEqual({
         evaluations: user1Evaluations,
-        userEvaluationsId: 'user_evaluation_id'
+        userEvaluationsId: 'user_evaluation_id',
       })
     })
 
@@ -78,11 +86,14 @@ suite('internal/remote/ApiClient', () => {
           'https://api.bucketeer.io/get_evaluations',
           (_req, res, _ctx) => {
             return res.networkError('network error')
-          }
-        )
+          },
+        ),
       )
 
-      const response = await apiClient.getEvaluations(user1, 'user_evaluation_id')
+      const response = await apiClient.getEvaluations(
+        user1,
+        'user_evaluation_id',
+      )
 
       assert(response.type === 'failure')
 
@@ -97,7 +108,7 @@ suite('internal/remote/ApiClient', () => {
         'api_key_value',
         'feature_tag_value',
         fetch,
-        200
+        200,
       )
       server = setupServerAndListen(
         rest.post(
@@ -106,13 +117,16 @@ suite('internal/remote/ApiClient', () => {
             return res(
               ctx.delay(1000),
               ctx.status(500),
-              ctx.body('{ "error": "super slow response"}')
+              ctx.body('{ "error": "super slow response"}'),
             )
-          }
-        )
+          },
+        ),
       )
 
-      const response = await apiClient.getEvaluations(user1, 'user_evaluation_id')
+      const response = await apiClient.getEvaluations(
+        user1,
+        'user_evaluation_id',
+      )
 
       assert(response.type === 'failure')
 
@@ -125,32 +139,37 @@ suite('internal/remote/ApiClient', () => {
   suite('registerEvents', () => {
     test('success', async () => {
       server = setupServerAndListen(
-        rest.post<RegisterEventsRequest, Record<string, never>, RegisterEventsResponse>(
-          'https://api.bucketeer.io/register_events',
-          async (req, res, ctx) => {
-            expect(req.headers.get('Authorization')).toBe('api_key_value')
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >('https://api.bucketeer.io/register_events', async (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('api_key_value')
 
-            const request = await req.json()
-            expect(request).toStrictEqual<RegisterEventsRequest>({
-              events: [evaluationEvent1, metricsEvent1]
-            })
-
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Length', '10'),
-              ctx.json<RegisterEventsResponse>({
-                errors: {
-                  [evaluationEvent1.id]: {
-                    retriable: true,
-                    message: 'error'
-                  }
-                }
-              }),
-            )
+          const request = await req.json()
+          expect(request).toStrictEqual<RegisterEventsRequest>({
+            events: [evaluationEvent1, metricsEvent1],
           })
+
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Length', '10'),
+            ctx.json<RegisterEventsResponse>({
+              errors: {
+                [evaluationEvent1.id]: {
+                  retriable: true,
+                  message: 'error',
+                },
+              },
+            }),
+          )
+        }),
       )
 
-      const response = await apiClient.registerEvents([evaluationEvent1, metricsEvent1])
+      const response = await apiClient.registerEvents([
+        evaluationEvent1,
+        metricsEvent1,
+      ])
 
       assert(response.type === 'success')
 
@@ -158,9 +177,9 @@ suite('internal/remote/ApiClient', () => {
         errors: {
           [evaluationEvent1.id]: {
             retriable: true,
-            message: 'error'
-          }
-        }
+            message: 'error',
+          },
+        },
       })
     })
 
@@ -170,11 +189,14 @@ suite('internal/remote/ApiClient', () => {
           'https://api.bucketeer.io/register_events',
           (_req, res, _ctx) => {
             return res.networkError('network error')
-          }
-        )
+          },
+        ),
       )
 
-      const response = await apiClient.registerEvents([evaluationEvent1, metricsEvent1])
+      const response = await apiClient.registerEvents([
+        evaluationEvent1,
+        metricsEvent1,
+      ])
 
       assert(response.type === 'failure')
 
@@ -188,7 +210,7 @@ suite('internal/remote/ApiClient', () => {
         'api_key_value',
         'feature_tag_value',
         fetch,
-        200
+        200,
       )
       server = setupServerAndListen(
         rest.post(
@@ -197,13 +219,16 @@ suite('internal/remote/ApiClient', () => {
             return res(
               ctx.delay(1000),
               ctx.status(500),
-              ctx.body('{ "error": "super slow response"}')
+              ctx.body('{ "error": "super slow response"}'),
             )
-          }
-        )
+          },
+        ),
       )
 
-      const response = await apiClient.registerEvents([evaluationEvent1, metricsEvent1])
+      const response = await apiClient.registerEvents([
+        evaluationEvent1,
+        metricsEvent1,
+      ])
 
       assert(response.type === 'failure')
 

--- a/test/mocks/evaluations.ts
+++ b/test/mocks/evaluations.ts
@@ -1,8 +1,7 @@
 import { Evaluation } from '../../src/internal/model/Evaluation'
 import { UserEvaluations } from '../../src/internal/model/UserEvaluations'
 
-
-export const evaluation1: Evaluation ={
+export const evaluation1: Evaluation = {
   id: 'test-feature-1:9:user_id_1',
   featureId: 'test-feature-1',
   featureVersion: 9,
@@ -29,14 +28,13 @@ export const evaluation2: Evaluation = {
     id: 'test-feature-2-variation-A',
     value: 'test variation value2',
   },
-  reason:{
+  reason: {
     type: 'CLIENT',
   },
-
 }
 
 export const evaluation3: Evaluation = {
-  id:'test-feature-1:9:user_id_2',
+  id: 'test-feature-1:9:user_id_2',
   featureId: 'test-feature-3',
   featureVersion: 9,
   userId: 'user_id_2',
@@ -53,9 +51,5 @@ export const evaluation3: Evaluation = {
 
 export const user1Evaluations: UserEvaluations = {
   id: '17388826713971171773',
-  evaluations: [
-    evaluation1,
-    evaluation2
-  ]
+  evaluations: [evaluation1, evaluation2],
 }
-

--- a/test/mocks/users.ts
+++ b/test/mocks/users.ts
@@ -2,9 +2,9 @@ import { User } from '../../src/internal/model/User'
 
 export const user1: User = {
   id: 'user_id_1',
-  data: {'age': '28'}
+  data: { age: '28' },
 }
 
 export const user2: User = {
-  id: 'user_id_2'
+  id: 'user_id_2',
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,7 +3,9 @@ import { SetupServer, setupServer } from 'msw/node'
 import { Clock, DefaultClock } from '../src/internal/Clock'
 import { DefaultIdGenerator, IdGenerator } from '../src/internal/IdGenerator'
 
-export function setupServerAndListen(...handlers: Array<RequestHandler>): SetupServer {
+export function setupServerAndListen(
+  ...handlers: Array<RequestHandler>
+): SetupServer {
   const server = setupServer(...handlers)
   server.listen({ onUnhandledRequest: 'error' })
   return server

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,16 @@
-import {resolve } from 'path'
+import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import packageJson from './package.json'
 
 export default defineConfig({
   define: {
-    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version)
+    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version),
   },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/main.ts'),
       name: 'Bucketeer',
-      fileName: 'bucketeer'
-    }
-  }
+      fileName: 'bucketeer',
+    },
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,10 +3,10 @@ import packageJson from './package.json'
 
 export default defineConfig({
   define: {
-    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version)
+    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version),
   },
   test: {
     setupFiles: ['test/globalSetup.ts'],
-    environment: 'happy-dom'
+    environment: 'happy-dom',
   },
 })


### PR DESCRIPTION
At first, I thought formatting via eslint is enough, but it turns out that eslint alone is not sufficient when we want to enforce the integrity of the code format.

Later I might add [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged) to run formatter on pre-commit hook.