### PR TITLE
feat: add TaskScheduler

### DIFF
--- a/src/internal/scheduler/EvaluationTask.ts
+++ b/src/internal/scheduler/EvaluationTask.ts
@@ -1,0 +1,72 @@
+import { BKTClientImpl } from '../../BKTClient'
+import { Component } from '../di/Component'
+import { ScheduledTask } from './ScheduledTask'
+
+const RETRY_POLLING_INTERVAL = 1_000 * 60 // 1 minute
+const MAX_RETRY_COUNT = 5
+
+export class EvaluationTask implements ScheduledTask {
+  constructor(
+    private component: Component,
+    private retryPollingInterval = RETRY_POLLING_INTERVAL,
+    private maxRetryCount = MAX_RETRY_COUNT,
+  ) {}
+
+  private timerId?: number
+  private retryCount = 0
+  private running = false
+
+  reschedule(interval: number) {
+    clearTimeout(this.timerId)
+    // fetchEvaluations call is asynchronous and setInterval does not wait for it.
+    // So have to use setTimeout instead.
+    this.timerId = window.setTimeout(() => {
+      this.fetchEvaluations()
+    }, interval)
+  }
+
+  async fetchEvaluations() {
+    try {
+      await BKTClientImpl.fetchEvaluationsInternal(this.component)
+
+      // success
+      if (this.retryCount > 0) {
+        // retried already, so reschedule with proper interval
+        this.retryCount = 0
+        this.reschedule(this.component.config().pollingInterval)
+      }
+    } catch (e) {
+      // error
+      const pollingInterval = this.component.config().pollingInterval
+      if (pollingInterval <= this.retryPollingInterval) {
+        // pollingInterval is short enough, do nothing
+        return
+      }
+      const canRetry = this.retryCount < this.maxRetryCount
+
+      if (canRetry) {
+        console.log('failed, retrying...', this.retryCount)
+        this.retryCount++
+        this.reschedule(this.retryPollingInterval)
+      } else {
+        // we already retried enough, let's get back to daily job
+        console.log('failed, retried enough')
+        this.retryCount = 0
+        this.reschedule(pollingInterval)
+      }
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  start(): void {
+    this.running = true
+    this.reschedule(this.component.config().pollingInterval)
+  }
+  stop(): void {
+    clearTimeout(this.timerId)
+    this.running = false
+  }
+}

--- a/src/internal/scheduler/EvaluationTask.ts
+++ b/src/internal/scheduler/EvaluationTask.ts
@@ -45,12 +45,10 @@ export class EvaluationTask implements ScheduledTask {
       const canRetry = this.retryCount < this.maxRetryCount
 
       if (canRetry) {
-        console.log('failed, retrying...', this.retryCount)
         this.retryCount++
         this.reschedule(this.retryPollingInterval)
       } else {
         // we already retried enough, let's get back to daily job
-        console.log('failed, retried enough')
         this.retryCount = 0
         this.reschedule(pollingInterval)
       }

--- a/src/internal/scheduler/EventTask.ts
+++ b/src/internal/scheduler/EventTask.ts
@@ -1,0 +1,53 @@
+import { Component } from '../di/Component'
+import { EventInteractor } from '../event/EventInteractor'
+import { ScheduledTask } from './ScheduledTask'
+
+type EventUpdateListener = Parameters<
+  EventInteractor['setEventUpdateListener']
+>[0]
+
+export class EventTask implements ScheduledTask {
+  constructor(private component: Component) {}
+
+  private timerId?: number | NodeJS.Timeout
+  private running = false
+
+  private eventUpdateListener: EventUpdateListener = async (_) => {
+    // send events if the cache exceeded the limit
+    const result = await this.component.eventInteractor().sendEvents(false)
+    if (result.type === 'success' && result.sent) {
+      // reschedule the background task if event is actually sent.
+      this.reschedule()
+    }
+  }
+
+  reschedule() {
+    clearTimeout(this.timerId)
+    this.timerId = setTimeout(() => {
+      // background task should flush(force-send) events
+      this.component
+        .eventInteractor()
+        .sendEvents(true)
+        .then(() => {
+          this.reschedule()
+        })
+    }, this.component.config().eventsFlushInterval)
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  start(): void {
+    this.running = true
+    this.component
+      .eventInteractor()
+      .setEventUpdateListener(this.eventUpdateListener)
+    this.reschedule()
+  }
+
+  stop(): void {
+    clearTimeout(this.timerId)
+    this.running = false
+  }
+}

--- a/src/internal/scheduler/ScheduledTask.ts
+++ b/src/internal/scheduler/ScheduledTask.ts
@@ -1,0 +1,5 @@
+export interface ScheduledTask {
+  isRunning(): boolean
+  start(): void
+  stop(): void
+}

--- a/src/internal/scheduler/TaskScheduler.ts
+++ b/src/internal/scheduler/TaskScheduler.ts
@@ -1,0 +1,23 @@
+import { Component } from '../di/Component'
+import { EvaluationTask } from './EvaluationTask'
+import { EventTask } from './EventTask'
+import { ScheduledTask } from './ScheduledTask'
+
+export class TaskScheduler {
+  private schedulers: ScheduledTask[]
+
+  constructor(private component: Component) {
+    this.schedulers = [
+      new EvaluationTask(this.component),
+      new EventTask(this.component),
+    ]
+  }
+
+  start() {
+    this.schedulers.forEach((scheduler) => scheduler.start())
+  }
+
+  stop() {
+    this.schedulers.forEach((scheduler) => scheduler.stop())
+  }
+}

--- a/test/BKTClient.spec.ts
+++ b/test/BKTClient.spec.ts
@@ -57,7 +57,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -90,7 +90,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.delay(1000),
@@ -126,7 +126,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -140,7 +140,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, _ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, _ctx) => {
           return res.networkError('network error')
         }),
       )
@@ -163,7 +163,7 @@ suite('BKTClient', () => {
         GetEvaluationsRequest,
         Record<string, never>,
         GetEvaluationsResponse
-      >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+      >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
         return res.once(
           ctx.status(200),
           ctx.json({
@@ -200,7 +200,7 @@ suite('BKTClient', () => {
             GetEvaluationsRequest,
             Record<string, never>,
             GetEvaluationsResponse
-          >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+          >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
             return res.once(
               ctx.status(200),
               ctx.json({
@@ -211,6 +211,13 @@ suite('BKTClient', () => {
                 userEvaluationsId: 'user_evaluation_id_value',
               }),
             )
+          }),
+          rest.post<
+            RegisterEventsRequest,
+            Record<string, never>,
+            RegisterEventsResponse
+          >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+            return res(ctx.status(200), ctx.json({}))
           }),
         )
 
@@ -232,7 +239,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -240,6 +247,13 @@ suite('BKTClient', () => {
               userEvaluationsId: 'user_evaluation_id_value',
             }),
           )
+        }),
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({}))
         }),
       )
 
@@ -270,7 +284,7 @@ suite('BKTClient', () => {
             GetEvaluationsRequest,
             Record<string, never>,
             GetEvaluationsResponse
-          >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+          >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
             return res.once(
               ctx.status(200),
               ctx.json({
@@ -281,6 +295,13 @@ suite('BKTClient', () => {
                 userEvaluationsId: 'user_evaluation_id_value',
               }),
             )
+          }),
+          rest.post<
+            RegisterEventsRequest,
+            Record<string, never>,
+            RegisterEventsResponse
+          >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+            return res(ctx.status(200), ctx.json({}))
           }),
         )
 
@@ -302,7 +323,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -310,6 +331,13 @@ suite('BKTClient', () => {
               userEvaluationsId: 'user_evaluation_id_value',
             }),
           )
+        }),
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({}))
         }),
       )
 
@@ -342,7 +370,7 @@ suite('BKTClient', () => {
             GetEvaluationsRequest,
             Record<string, never>,
             GetEvaluationsResponse
-          >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+          >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
             return res.once(
               ctx.status(200),
               ctx.json({
@@ -353,6 +381,13 @@ suite('BKTClient', () => {
                 userEvaluationsId: 'user_evaluation_id_value',
               }),
             )
+          }),
+          rest.post<
+            RegisterEventsRequest,
+            Record<string, never>,
+            RegisterEventsResponse
+          >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+            return res(ctx.status(200), ctx.json({}))
           }),
         )
 
@@ -389,7 +424,7 @@ suite('BKTClient', () => {
             GetEvaluationsRequest,
             Record<string, never>,
             GetEvaluationsResponse
-          >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+          >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
             return res.once(
               ctx.status(200),
               ctx.json({
@@ -400,6 +435,13 @@ suite('BKTClient', () => {
                 userEvaluationsId: 'user_evaluation_id_value',
               }),
             )
+          }),
+          rest.post<
+            RegisterEventsRequest,
+            Record<string, never>,
+            RegisterEventsResponse
+          >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+            return res(ctx.status(200), ctx.json({}))
           }),
         )
 
@@ -425,7 +467,7 @@ suite('BKTClient', () => {
         GetEvaluationsRequest,
         Record<string, never>,
         GetEvaluationsResponse
-      >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+      >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
         return res.once(
           ctx.status(200),
           ctx.json({
@@ -433,6 +475,13 @@ suite('BKTClient', () => {
             userEvaluationsId: 'user_evaluation_id_value',
           }),
         )
+      }),
+      rest.post<
+        RegisterEventsRequest,
+        Record<string, never>,
+        RegisterEventsResponse
+      >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json({}))
       }),
     )
 
@@ -460,7 +509,7 @@ suite('BKTClient', () => {
         GetEvaluationsRequest,
         Record<string, never>,
         GetEvaluationsResponse
-      >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+      >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
         return res.once(
           ctx.status(200),
           ctx.json({
@@ -489,7 +538,7 @@ suite('BKTClient', () => {
         GetEvaluationsRequest,
         Record<string, never>,
         GetEvaluationsResponse
-      >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+      >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
         return res.once(
           ctx.status(200),
           ctx.json({
@@ -497,6 +546,13 @@ suite('BKTClient', () => {
             userEvaluationsId: 'user_evaluation_id_value',
           }),
         )
+      }),
+      rest.post<
+        RegisterEventsRequest,
+        Record<string, never>,
+        RegisterEventsResponse
+      >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json({}))
       }),
     )
 
@@ -536,7 +592,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -552,7 +608,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -563,6 +619,13 @@ suite('BKTClient', () => {
               userEvaluationsId: 'user_evaluation_id_value_updated',
             }),
           )
+        }),
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({}))
         }),
       )
 
@@ -589,7 +652,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -602,7 +665,7 @@ suite('BKTClient', () => {
           )
         }),
         rest.post<GetEvaluationsRequest, Record<string, never>, ErrorResponse>(
-          'https://api.bucketeer.io/get_evaluations',
+          `${config.apiEndpoint}/get_evaluations`,
           (_req, res, ctx) => {
             return res.once(
               ctx.status(500),
@@ -615,6 +678,13 @@ suite('BKTClient', () => {
             )
           },
         ),
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({}))
+        }),
       )
 
       await initializeBKTClient(config, toBKTUser(user1), 1000)
@@ -645,7 +715,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -658,7 +728,7 @@ suite('BKTClient', () => {
           RegisterEventsRequest,
           Record<string, never>,
           RegisterEventsResponse
-        >('https://api.bucketeer.io/register_events', (req, res, ctx) => {
+        >(`${config.apiEndpoint}/register_events`, (req, res, ctx) => {
           return res.once(ctx.status(200), ctx.json({}))
         }),
       )
@@ -685,7 +755,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -695,7 +765,7 @@ suite('BKTClient', () => {
           )
         }),
         rest.post<RegisterEventsRequest, Record<string, never>, ErrorResponse>(
-          'https://api.bucketeer.io/register_events',
+          `${config.apiEndpoint}/register_events`,
           (_req, res, ctx) => {
             return res.once(
               ctx.status(500),
@@ -736,7 +806,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({
@@ -772,7 +842,7 @@ suite('BKTClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', (_req, res, ctx) => {
+        >(`${config.apiEndpoint}/get_evaluations`, (_req, res, ctx) => {
           return res.once(
             ctx.status(200),
             ctx.json({

--- a/test/internal/evaluation/EvaluationInteractor.spec.ts
+++ b/test/internal/evaluation/EvaluationInteractor.spec.ts
@@ -3,7 +3,7 @@ import { SetupServer } from 'msw/node'
 import { expect, suite, test, beforeEach, afterEach, vi } from 'vitest'
 import fetch from 'cross-fetch'
 import assert from 'assert'
-import { defineBKTConfig } from '../../../src/BKTConfig'
+import { BKTConfig, defineBKTConfig } from '../../../src/BKTConfig'
 import { DefaultComponent } from '../../../src/internal/di/Component'
 import { DataModule } from '../../../src/internal/di/DataModule'
 import { InteractorModule } from '../../../src/internal/di/InteractorModule'
@@ -22,22 +22,21 @@ import { setupServerAndListen } from '../../utils'
 
 suite('internal/evaluation/EvaluationInteractor', () => {
   let server: SetupServer
+  let config: BKTConfig
   let component: DefaultComponent
   let interactor: EvaluationInteractor
   let evaluationStorage: EvaluationStorageImpl
 
   beforeEach(() => {
+    config = defineBKTConfig({
+      apiKey: 'api_key_value',
+      apiEndpoint: 'https://api.bucketeer.io',
+      featureTag: 'feature_tag_value',
+      appVersion: '1.2.3',
+      fetch,
+    })
     component = new DefaultComponent(
-      new DataModule(
-        user1,
-        defineBKTConfig({
-          apiKey: 'api_key_value',
-          apiEndpoint: 'https://api.bucketeer.io',
-          featureTag: 'feature_tag_value',
-          appVersion: '1.2.3',
-          fetch,
-        }),
-      ),
+      new DataModule(user1, config),
       new InteractorModule(),
     )
 
@@ -58,18 +57,15 @@ suite('internal/evaluation/EvaluationInteractor', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >(
-          'https://api.bucketeer.io/get_evaluations',
-          async (_req, res, ctx) => {
-            return res(
-              ctx.status(200),
-              ctx.json({
-                evaluations: user1Evaluations,
-                userEvaluationsId: 'user_evaluation_id_value',
-              }),
-            )
-          },
-        ),
+        >(`${config.apiEndpoint}/get_evaluations`, async (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              evaluations: user1Evaluations,
+              userEvaluationsId: 'user_evaluation_id_value',
+            }),
+          )
+        }),
       )
 
       expect(
@@ -108,38 +104,32 @@ suite('internal/evaluation/EvaluationInteractor', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >(
-          'https://api.bucketeer.io/get_evaluations',
-          async (_req, res, ctx) => {
-            return res.once(
-              ctx.status(200),
-              ctx.json({
-                evaluations: user1Evaluations,
-                userEvaluationsId: 'user_evaluation_id_value',
-              }),
-            )
-          },
-        ),
+        >(`${config.apiEndpoint}/get_evaluations`, async (_req, res, ctx) => {
+          return res.once(
+            ctx.status(200),
+            ctx.json({
+              evaluations: user1Evaluations,
+              userEvaluationsId: 'user_evaluation_id_value',
+            }),
+          )
+        }),
         // second request
         rest.post<
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >(
-          'https://api.bucketeer.io/get_evaluations',
-          async (_req, res, ctx) => {
-            return res.once(
-              ctx.status(200),
-              ctx.json({
-                evaluations: {
-                  ...user1Evaluations,
-                  evaluations: [newEvaluation],
-                },
-                userEvaluationsId: 'user_evaluation_id_value_updated',
-              }),
-            )
-          },
-        ),
+        >(`${config.apiEndpoint}/get_evaluations`, async (_req, res, ctx) => {
+          return res.once(
+            ctx.status(200),
+            ctx.json({
+              evaluations: {
+                ...user1Evaluations,
+                evaluations: [newEvaluation],
+              },
+              userEvaluationsId: 'user_evaluation_id_value_updated',
+            }),
+          )
+        }),
       )
 
       const mockListener = vi.fn<[], void>()
@@ -176,18 +166,15 @@ suite('internal/evaluation/EvaluationInteractor', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >(
-          'https://api.bucketeer.io/get_evaluations',
-          async (_req, res, ctx) => {
-            return res(
-              ctx.status(200),
-              ctx.json({
-                evaluations: user1Evaluations,
-                userEvaluationsId: 'user_evaluation_id_value',
-              }),
-            )
-          },
-        ),
+        >(`${config.apiEndpoint}/get_evaluations`, async (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              evaluations: user1Evaluations,
+              userEvaluationsId: 'user_evaluation_id_value',
+            }),
+          )
+        }),
       )
 
       const mockListener = vi.fn<[], void>()

--- a/test/internal/remote/ApiClient.spec.ts
+++ b/test/internal/remote/ApiClient.spec.ts
@@ -18,12 +18,13 @@ import { RegisterEventsResponse } from '../../../src/internal/model/response/Reg
 import { setupServerAndListen } from '../../utils'
 
 suite('internal/remote/ApiClient', () => {
+  const endpoint = 'https://api.bucketeer.io'
   let server: SetupServer
   let apiClient: ApiClient
 
   beforeEach(() => {
     apiClient = new ApiClientImpl(
-      'https://api.bucketeer.io',
+      endpoint,
       'api_key_value',
       'feature_tag_value',
       fetch,
@@ -41,7 +42,7 @@ suite('internal/remote/ApiClient', () => {
           GetEvaluationsRequest,
           Record<string, never>,
           GetEvaluationsResponse
-        >('https://api.bucketeer.io/get_evaluations', async (req, res, ctx) => {
+        >(`${endpoint}/get_evaluations`, async (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('api_key_value')
 
           const request = await req.json()
@@ -82,12 +83,9 @@ suite('internal/remote/ApiClient', () => {
 
     test('network error', async () => {
       server = setupServerAndListen(
-        rest.post(
-          'https://api.bucketeer.io/get_evaluations',
-          (_req, res, _ctx) => {
-            return res.networkError('network error')
-          },
-        ),
+        rest.post(`${endpoint}/get_evaluations`, (_req, res, _ctx) => {
+          return res.networkError('network error')
+        }),
       )
 
       const response = await apiClient.getEvaluations(
@@ -104,23 +102,20 @@ suite('internal/remote/ApiClient', () => {
 
     test('timeout error', async () => {
       apiClient = new ApiClientImpl(
-        'https://api.bucketeer.io',
+        endpoint,
         'api_key_value',
         'feature_tag_value',
         fetch,
         200,
       )
       server = setupServerAndListen(
-        rest.post(
-          'https://api.bucketeer.io/get_evaluations',
-          async (_req, res, ctx) => {
-            return res(
-              ctx.delay(1000),
-              ctx.status(500),
-              ctx.body('{ "error": "super slow response"}'),
-            )
-          },
-        ),
+        rest.post(`${endpoint}/get_evaluations`, async (_req, res, ctx) => {
+          return res(
+            ctx.delay(1000),
+            ctx.status(500),
+            ctx.body('{ "error": "super slow response"}'),
+          )
+        }),
       )
 
       const response = await apiClient.getEvaluations(
@@ -143,7 +138,7 @@ suite('internal/remote/ApiClient', () => {
           RegisterEventsRequest,
           Record<string, never>,
           RegisterEventsResponse
-        >('https://api.bucketeer.io/register_events', async (req, res, ctx) => {
+        >(`${endpoint}/register_events`, async (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('api_key_value')
 
           const request = await req.json()
@@ -185,12 +180,9 @@ suite('internal/remote/ApiClient', () => {
 
     test('network error', async () => {
       server = setupServerAndListen(
-        rest.post(
-          'https://api.bucketeer.io/register_events',
-          (_req, res, _ctx) => {
-            return res.networkError('network error')
-          },
-        ),
+        rest.post(`${endpoint}/register_events`, (_req, res, _ctx) => {
+          return res.networkError('network error')
+        }),
       )
 
       const response = await apiClient.registerEvents([
@@ -206,23 +198,20 @@ suite('internal/remote/ApiClient', () => {
 
     test('timeout error', async () => {
       apiClient = new ApiClientImpl(
-        'https://api.bucketeer.io',
+        endpoint,
         'api_key_value',
         'feature_tag_value',
         fetch,
         200,
       )
       server = setupServerAndListen(
-        rest.post(
-          'https://api.bucketeer.io/register_events',
-          async (_req, res, ctx) => {
-            return res(
-              ctx.delay(1000),
-              ctx.status(500),
-              ctx.body('{ "error": "super slow response"}'),
-            )
-          },
-        ),
+        rest.post(`${endpoint}/register_events`, async (_req, res, ctx) => {
+          return res(
+            ctx.delay(1000),
+            ctx.status(500),
+            ctx.body('{ "error": "super slow response"}'),
+          )
+        }),
       )
 
       const response = await apiClient.registerEvents([

--- a/test/internal/scheduler/EventTask.spec.ts
+++ b/test/internal/scheduler/EventTask.spec.ts
@@ -1,0 +1,151 @@
+import { rest } from 'msw'
+import { SetupServer } from 'msw/node'
+import { beforeEach, afterEach, expect, suite, test, vi } from 'vitest'
+import fetch from 'cross-fetch'
+import { destroyBKTClient } from '../../../src/BKTClient'
+import { BKTConfig, defineBKTConfig } from '../../../src/BKTConfig'
+import { DefaultComponent } from '../../../src/internal/di/Component'
+import { DataModule } from '../../../src/internal/di/DataModule'
+import { RegisterEventsRequest } from '../../../src/internal/model/request/RegisterEventsRequest'
+import { RegisterEventsResponse } from '../../../src/internal/model/response/RegisterEventsResponse'
+import { EventTask } from '../../../src/internal/scheduler/EventTask'
+import { setupServerAndListen } from '../../utils'
+import { InteractorModule } from '../../../src/internal/di/InteractorModule'
+import { user1 } from '../../mocks/users'
+import { evaluation1, evaluation2 } from '../../mocks/evaluations'
+
+suite('internal/scheduler/EventTask', () => {
+  let server: SetupServer
+  let config: BKTConfig
+  let component: DefaultComponent
+  let task: EventTask
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+
+    config = defineBKTConfig({
+      apiKey: 'api_key_value',
+      apiEndpoint: 'https://api.bucketeer.io',
+      featureTag: 'feature_tag_value',
+      appVersion: '1.2.3',
+      eventsMaxBatchQueueCount: 3,
+      eventsFlushInterval: 1000,
+      fetch,
+    })
+
+    component = new DefaultComponent(
+      new DataModule(user1, config),
+      new InteractorModule(),
+    )
+  })
+
+  afterEach(() => {
+    destroyBKTClient()
+    server?.close()
+    localStorage.clear()
+    task.stop()
+
+    vi.useRealTimers()
+  })
+
+  test('start', async () => {
+    let requestCount = 0
+    server = setupServerAndListen(
+      rest.post<
+        RegisterEventsRequest,
+        Record<string, never>,
+        RegisterEventsResponse
+      >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+        requestCount++
+        return res(ctx.status(200), ctx.json({}))
+      }),
+    )
+
+    task = new EventTask(component)
+
+    task.start()
+
+    component
+      .eventInteractor()
+      .trackDefaultEvaluationEvent(
+        'feature_tag_value',
+        user1,
+        'variation_id_value',
+      )
+
+    expect(requestCount).toBe(0)
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(requestCount).toBe(1)
+    expect(task.isRunning()).toBe(true)
+  })
+
+  test('send via eventUpdateListener', async () => {
+    let requestCount = 0
+
+    server = setupServerAndListen(
+      rest.post<
+        RegisterEventsRequest,
+        Record<string, never>,
+        RegisterEventsResponse
+      >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+        requestCount++
+        return res(ctx.status(200), ctx.json({}))
+      }),
+    )
+
+    task = new EventTask(component)
+
+    task.start()
+
+    const interactor = component.eventInteractor()
+    interactor.trackEvaluationEvent('feature_tag_value', user1, evaluation1)
+    interactor.trackEvaluationEvent('feature_tag_value', user1, evaluation2)
+    interactor.trackGoalEvent('feature_tag_value', user1, 'goal_id_value', 0.4)
+
+    expect(requestCount).toBe(0)
+
+    await vi.advanceTimersToNextTimerAsync()
+
+    expect(requestCount).toBe(1)
+    expect(task.isRunning()).toBe(true)
+  })
+
+  test('stop should cancel timer', async () => {
+    test('start', async () => {
+      let requestCount = 0
+      server = setupServerAndListen(
+        rest.post<
+          RegisterEventsRequest,
+          Record<string, never>,
+          RegisterEventsResponse
+        >(`${config.apiEndpoint}/register_events`, (_req, res, ctx) => {
+          requestCount++
+          return res(ctx.status(200), ctx.json({}))
+        }),
+      )
+
+      task = new EventTask(component)
+
+      task.start()
+
+      component
+        .eventInteractor()
+        .trackDefaultEvaluationEvent(
+          'feature_tag_value',
+          user1,
+          'variation_id_value',
+        )
+
+      task.stop()
+
+      expect(requestCount).toBe(0)
+
+      await vi.runOnlyPendingTimersAsync()
+
+      expect(requestCount).toBe(0)
+      expect(task.isRunning()).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Added TaskScheduler.

Implementation is basically the same as android-client-sdk, but there is a difference: This SDK only has foreground schedulers. Behavior, when a browser tab is not active, depends on the browser's spec.

The basic implementation should be finished now.
Remaining tasks are

- E2E tests
- example
- Release automation