### PR TITLE
chore(ci): make separate renovate update group for vitest deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "18.15.11",
     "@typescript-eslint/eslint-plugin": "5.57.0",
     "@typescript-eslint/parser": "5.57.0",
-    "@vitest/browser": "0.29.8",
+    "@vitest/browser": "0.29.7",
     "cross-fetch": "3.1.5",
     "eslint": "8.37.0",
     "eslint-config-prettier": "8.8.0",
@@ -43,7 +43,7 @@
     "prettier": "2.8.7",
     "typescript": "5.0.3",
     "vite": "4.2.1",
-    "vitest": "0.29.8",
+    "vitest": "0.29.7",
     "webdriverio": "8.6.9"
   },
   "packageManager": "pnpm@8.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 5.57.0
         version: 5.57.0(eslint@8.37.0)(typescript@5.0.3)
       '@vitest/browser':
-        specifier: 0.29.8
-        version: 0.29.8(vitest@0.29.8)
+        specifier: 0.29.7
+        version: 0.29.7(vitest@0.29.7)
       cross-fetch:
         specifier: 3.1.5
         version: 3.1.5
@@ -53,8 +53,8 @@ importers:
         specifier: 4.2.1
         version: 4.2.1(@types/node@18.15.11)
       vitest:
-        specifier: 0.29.8
-        version: 0.29.8(@vitest/browser@0.29.8)(happy-dom@9.1.0)(webdriverio@8.6.9)
+        specifier: 0.29.7
+        version: 0.29.7(@vitest/browser@0.29.7)(happy-dom@9.1.0)(webdriverio@8.6.9)
       webdriverio:
         specifier: 8.6.9
         version: 8.6.9(typescript@5.0.3)
@@ -673,44 +673,44 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@vitest/browser@0.29.8(vitest@0.29.8):
-    resolution: {integrity: sha512-EEZV9GOOVrNaSE1eg41e3mUFzRVnfvemJl2aDIkVHqvFWuueMe9MFel+KipXyLUGTxmq40q++3wTkEX58rhVHA==}
+  /@vitest/browser@0.29.7(vitest@0.29.7):
+    resolution: {integrity: sha512-e94jdP49jBFaUFNrC5FJRJ+zD/f/XSVYovWpkxvTtpUjDbnA4SA2yUZzyJ+0XfO10r8CgTHG3UMmrSALHqwGlw==}
     peerDependencies:
       vitest: '>=0.29.4'
     dependencies:
-      '@vitest/runner': 0.29.8
+      '@vitest/runner': 0.29.7
       local-pkg: 0.4.3
       mlly: 1.2.0
       modern-node-polyfills: 0.1.0
       rollup-plugin-node-polyfills: 0.2.1
       sirv: 2.0.2
-      vitest: 0.29.8(@vitest/browser@0.29.8)(happy-dom@9.1.0)(webdriverio@8.6.9)
+      vitest: 0.29.7(@vitest/browser@0.29.7)(happy-dom@9.1.0)(webdriverio@8.6.9)
     dev: true
 
-  /@vitest/expect@0.29.8:
-    resolution: {integrity: sha512-xlcVXn5I5oTq6NiZSY3ykyWixBxr5mG8HYtjvpgg6KaqHm0mvhX18xuwl5YGxIRNt/A5jidd7CWcNHrSvgaQqQ==}
+  /@vitest/expect@0.29.7:
+    resolution: {integrity: sha512-UtG0tW0DP6b3N8aw7PHmweKDsvPv4wjGvrVZW7OSxaFg76ShtVdMiMcUkZJgCE8QWUmhwaM0aQhbbVLo4F4pkA==}
     dependencies:
-      '@vitest/spy': 0.29.8
-      '@vitest/utils': 0.29.8
+      '@vitest/spy': 0.29.7
+      '@vitest/utils': 0.29.7
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner@0.29.8:
-    resolution: {integrity: sha512-FzdhnRDwEr/A3Oo1jtIk/B952BBvP32n1ObMEb23oEJNO+qO5cBet6M2XWIDQmA7BDKGKvmhUf2naXyp/2JEwQ==}
+  /@vitest/runner@0.29.7:
+    resolution: {integrity: sha512-Yt0+csM945+odOx4rjZSjibQfl2ymxqVsmYz6sO2fiO5RGPYDFCo60JF6tLL9pz4G/kjY4irUxadeB1XT+H1jg==}
     dependencies:
-      '@vitest/utils': 0.29.8
+      '@vitest/utils': 0.29.7
       p-limit: 4.0.0
       pathe: 1.1.0
     dev: true
 
-  /@vitest/spy@0.29.8:
-    resolution: {integrity: sha512-VdjBe9w34vOMl5I5mYEzNX8inTxrZ+tYUVk9jxaZJmHFwmDFC/GV3KBFTA/JKswr3XHvZL+FE/yq5EVhb6pSAw==}
+  /@vitest/spy@0.29.7:
+    resolution: {integrity: sha512-IalL0iO6A6Xz8hthR8sctk6ZS//zVBX48EiNwQguYACdgdei9ZhwMaBFV70mpmeYAFCRAm+DpoFHM5470Im78A==}
     dependencies:
       tinyspy: 1.1.1
     dev: true
 
-  /@vitest/utils@0.29.8:
-    resolution: {integrity: sha512-qGzuf3vrTbnoY+RjjVVIBYfuWMjn3UMUqyQtdGNZ6ZIIyte7B37exj6LaVkrZiUTvzSadVvO/tJm8AEgbGCBPg==}
+  /@vitest/utils@0.29.7:
+    resolution: {integrity: sha512-vNgGadp2eE5XKCXtZXL5UyNEDn68npSct75OC9AlELenSK0DiV1Mb9tfkwJHKjRb69iek+e79iipoJx8+s3SdA==}
     dependencies:
       cli-truncate: 3.1.0
       diff: 5.1.0
@@ -4052,8 +4052,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.29.8(@types/node@18.15.11):
-    resolution: {integrity: sha512-b6OtCXfk65L6SElVM20q5G546yu10/kNrhg08afEoWlFRJXFq9/6glsvSVY+aI6YeC1tu2TtAqI2jHEQmOmsFw==}
+  /vite-node@0.29.7(@types/node@18.15.11):
+    resolution: {integrity: sha512-PakCZLvz37yFfUPWBnLa1OYHPCGm5v4pmRrTcFN4V/N/T3I6tyP3z07S//9w+DdeL7vVd0VSeyMZuAh+449ZWw==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     dependencies:
@@ -4107,8 +4107,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.29.8(@vitest/browser@0.29.8)(happy-dom@9.1.0)(webdriverio@8.6.9):
-    resolution: {integrity: sha512-JIAVi2GK5cvA6awGpH0HvH/gEG9PZ0a/WoxdiV3PmqK+3CjQMf8c+J/Vhv4mdZ2nRyXFw66sAg6qz7VNkaHfDQ==}
+  /vitest@0.29.7(@vitest/browser@0.29.7)(happy-dom@9.1.0)(webdriverio@8.6.9):
+    resolution: {integrity: sha512-aWinOSOu4jwTuZHkb+cCyrqQ116Q9TXaJrNKTHudKBknIpR0VplzeaOUuDF9jeZcrbtQKZQt6yrtd+eakbaxHg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -4117,7 +4117,6 @@ packages:
       '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
-      playwright: '*'
       safaridriver: '*'
       webdriverio: '*'
     peerDependenciesMeta:
@@ -4131,8 +4130,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-      playwright:
-        optional: true
       safaridriver:
         optional: true
       webdriverio:
@@ -4141,11 +4138,11 @@ packages:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
       '@types/node': 18.15.11
-      '@vitest/browser': 0.29.8(vitest@0.29.8)
-      '@vitest/expect': 0.29.8
-      '@vitest/runner': 0.29.8
-      '@vitest/spy': 0.29.8
-      '@vitest/utils': 0.29.8
+      '@vitest/browser': 0.29.7(vitest@0.29.7)
+      '@vitest/expect': 0.29.7
+      '@vitest/runner': 0.29.7
+      '@vitest/spy': 0.29.7
+      '@vitest/utils': 0.29.7
       acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
@@ -4162,7 +4159,7 @@ packages:
       tinypool: 0.4.0
       tinyspy: 1.1.1
       vite: 4.2.1(@types/node@18.15.11)
-      vite-node: 0.29.8(@types/node@18.15.11)
+      vite-node: 0.29.7(@types/node@18.15.11)
       webdriverio: 8.6.9(typescript@5.0.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,19 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "excludePackageNames": []
+      "excludePackageNames": [
+        "@vitest/browser",
+        "vitest",
+        "webdriverio"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "@vitest/browser",
+        "vitest",
+        "webdriverio"
+      ],
+      "groupName": "vitest"
     }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,9 @@ export default defineConfig({
   test: {
     setupFiles: ['test/globalSetup.ts'],
     environment: 'happy-dom',
+    browser: {
+      provider: 'webdriverio',
+      name: 'chrome',
+    }
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     browser: {
       provider: 'webdriverio',
       name: 'chrome',
-    }
+    },
   },
 })


### PR DESCRIPTION
related: #39 

vitest v0.29.8 seems to have an issue with browser testing(see [e2e workflow results](https://github.com/bucketeer-io/javascript-client-sdk/actions/workflows/e2e.yml) not finishing), so I did:

- downgrade vitest to 0.29.7, which was working
- create a separate renovate group for vitest-related dependencies, so that it's not updated along with other dependencies.

To avoid this kind of regression, we need to run e2e test upon each PR, but it could leak API secrets(though I don't think it can cause serious incident). What do you think?
