### PR TITLE
chore: set default value for track interface

### DIFF
--- a/src/BKTClient.ts
+++ b/src/BKTClient.ts
@@ -89,7 +89,7 @@ export class BKTClientImpl implements BKTClient {
     }
   }
 
-  track(goalId: string, value: number): void {
+  track(goalId: string, value = 0.0): void {
     this.component
       .eventInteractor()
       .trackGoalEvent(

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -21,7 +21,7 @@ interface RawBKTConfig {
   apiEndpoint: string
   featureTag: string
   eventsFlushInterval?: number
-  eventsMaxBatchQueueCount?: number
+  eventsMaxQueueSize?: number
   pollingInterval?: number
   appVersion: string
   storageKeyPrefix?: string
@@ -31,7 +31,7 @@ interface RawBKTConfig {
 
 export interface BKTConfig extends RawBKTConfig {
   eventsFlushInterval: number
-  eventsMaxBatchQueueCount: number
+  eventsMaxQueueSize: number
   pollingInterval: number
   userAgent: string
   fetch: FetchLike
@@ -40,7 +40,7 @@ export interface BKTConfig extends RawBKTConfig {
 export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
   const result: BKTConfig = {
     eventsFlushInterval: MINIMUM_FLUSH_INTERVAL_MILLIS,
-    eventsMaxBatchQueueCount: DEFAULT_MAX_QUEUE_SIZE,
+    eventsMaxQueueSize: DEFAULT_MAX_QUEUE_SIZE,
     pollingInterval: DEFAULT_POLLING_INTERVAL_MILLIS,
     storageKeyPrefix: '',
     userAgent: window.navigator.userAgent,

--- a/src/internal/di/Component.ts
+++ b/src/internal/di/Component.ts
@@ -43,7 +43,7 @@ export class DefaultComponent implements Component {
   eventInteractor(): EventInteractor {
     if (!this._eventInteractor) {
       this._eventInteractor = this.interactorModule.eventInteractor(
-        this.dataModule.config().eventsMaxBatchQueueCount,
+        this.dataModule.config().eventsMaxQueueSize,
         this.dataModule.apiClient(),
         this.dataModule.eventStorage(),
         this.dataModule.idGenerator(),

--- a/test/BKTClient.spec.ts
+++ b/test/BKTClient.spec.ts
@@ -39,7 +39,7 @@ suite('BKTClient', () => {
       apiEndpoint: 'https://api.bucketeer.io',
       featureTag: 'feature_tag_value',
       appVersion: '1.2.3',
-      eventsMaxBatchQueueCount: 3,
+      eventsMaxQueueSize: 3,
       fetch,
     })
   })

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -19,7 +19,7 @@ suite('defineBKTConfig', () => {
     expect(result).toStrictEqual({
       ...defaultConfig,
       eventsFlushInterval: 60_000,
-      eventsMaxBatchQueueCount: 50,
+      eventsMaxQueueSize: 50,
       pollingInterval: 600_000,
       storageKeyPrefix: '',
       fetch: window.fetch,

--- a/test/internal/event/EventInteractor.spec.ts
+++ b/test/internal/event/EventInteractor.spec.ts
@@ -63,7 +63,7 @@ suite('internal/event/EventInteractor', () => {
       apiEndpoint: 'https://api.bucketeer.io',
       featureTag: 'feature_tag_value',
       appVersion: '1.2.3',
-      eventsMaxBatchQueueCount: 3,
+      eventsMaxQueueSize: 3,
       userAgent: 'user_agent_value',
       fetch,
     })
@@ -430,7 +430,7 @@ suite('internal/event/EventInteractor', () => {
       expect(eventStorage.getAll()).toHaveLength(3)
     })
 
-    test('current cache is less than `eventsMaxBatchQueueCount`', async () => {
+    test('current cache is less than `eventsMaxQueueSize`', async () => {
       interactor.trackSuccess(ApiId.GET_EVALUATION, 'feature_tag_value', 1, 723)
 
       expect(eventStorage.getAll()).toHaveLength(2)

--- a/test/internal/scheduler/EvalauationTask.spec.ts
+++ b/test/internal/scheduler/EvalauationTask.spec.ts
@@ -28,7 +28,7 @@ suite('internal/scheduler/EventTask', () => {
       apiEndpoint: 'https://api.bucketeer.io',
       featureTag: 'feature_tag_value',
       appVersion: '1.2.3',
-      eventsMaxBatchQueueCount: 3,
+      eventsMaxQueueSize: 3,
       pollingInterval: 1_000 * 120, // 2 minutes
       fetch,
     })

--- a/test/internal/scheduler/EventTask.spec.ts
+++ b/test/internal/scheduler/EventTask.spec.ts
@@ -28,7 +28,7 @@ suite('internal/scheduler/EventTask', () => {
       apiEndpoint: 'https://api.bucketeer.io',
       featureTag: 'feature_tag_value',
       appVersion: '1.2.3',
-      eventsMaxBatchQueueCount: 3,
+      eventsMaxQueueSize: 3,
       eventsFlushInterval: 1000,
       fetch,
     })


### PR DESCRIPTION
Things done.

- Set default value for track interface because it is optional
- Renamed eventsMaxBatchQueueCount -> eventsMaxQueueSize for consistency with other SDKs

Note: Since this SDK is not being used in production yet, releasing it as a minor version is unnecessary.