### PR TITLE
chore: add variation name property to BKTEvaluation

### DIFF
--- a/e2e/BKTClient.spec.ts
+++ b/e2e/BKTClient.spec.ts
@@ -50,11 +50,12 @@ suite('e2e/BKTClientTest', () => {
     const detail = client.evaluationDetails(FEATURE_ID_STRING)
 
     expect(detail).toBeEvaluation({
-      id: 'feature-js-e2e-string:4:bucketeer-js-user-id-1',
+      id: 'feature-js-e2e-string:5:bucketeer-js-user-id-1',
       featureId: FEATURE_ID_STRING,
-      featureVersion: 4,
+      featureVersion: 5,
       userId: USER_ID,
       variationId: '802f2b29-a5c5-47d1-b5ba-f457d224c7b2',
+      variationName: 'variation 2',
       variationValue: 'value-2',
       reason: 'RULE',
     })

--- a/e2e/evaluations.spec.ts
+++ b/e2e/evaluations.spec.ts
@@ -57,11 +57,12 @@ suite('e2e/evaluations', () => {
 
       const detail = client.evaluationDetails(FEATURE_ID_STRING)
       expect(detail).toBeEvaluation({
-        id: 'feature-js-e2e-string:4:bucketeer-js-user-id-1',
+        id: 'feature-js-e2e-string:5:bucketeer-js-user-id-1',
         featureId: FEATURE_ID_STRING,
-        featureVersion: 4,
+        featureVersion: 5,
         userId: USER_ID,
         variationId: '87e0a1ef-a0cb-49da-8460-289948f117ba',
+        variationName: 'variation ',
         variationValue: 'value-1',
         reason: 'DEFAULT',
       })
@@ -85,11 +86,12 @@ suite('e2e/evaluations', () => {
 
         const detail = client.evaluationDetails(FEATURE_ID_INT)
         expect(detail).toBeEvaluation({
-          id: 'feature-js-e2e-int:2:bucketeer-js-user-id-1',
+          id: 'feature-js-e2e-int:3:bucketeer-js-user-id-1',
           featureId: FEATURE_ID_INT,
-          featureVersion: 2,
+          featureVersion: 3,
           userId: USER_ID,
           variationId: '6079c503-c281-4561-b870-c2c59a75e6a6',
+          variationName: 'variation 10',
           variationValue: '10',
           reason: 'DEFAULT',
         })
@@ -112,11 +114,12 @@ suite('e2e/evaluations', () => {
 
         const detail = client.evaluationDetails(FEATURE_ID_DOUBLE)
         expect(detail).toBeEvaluation({
-          id: 'feature-js-e2e-double:2:bucketeer-js-user-id-1',
+          id: 'feature-js-e2e-double:3:bucketeer-js-user-id-1',
           featureId: FEATURE_ID_DOUBLE,
-          featureVersion: 2,
+          featureVersion: 3,
           userId: USER_ID,
           variationId: '2d4a213c-1721-434b-8484-1b72826ece98',
+          variationName: 'variation 2.1',
           variationValue: '2.1',
           reason: 'DEFAULT',
         })
@@ -140,11 +143,12 @@ suite('e2e/evaluations', () => {
 
       const detail = client.evaluationDetails(FEATURE_ID_BOOLEAN)
       expect(detail).toBeEvaluation({
-        id: 'feature-js-e2e-boolean:2:bucketeer-js-user-id-1',
+        id: 'feature-js-e2e-boolean:3:bucketeer-js-user-id-1',
         featureId: FEATURE_ID_BOOLEAN,
-        featureVersion: 2,
+        featureVersion: 3,
         userId: USER_ID,
         variationId: '4fab39c8-bf62-4a78-8a10-1b8bc3dd3806',
+        variationName: 'variation true',
         variationValue: 'true',
         reason: 'DEFAULT',
       })
@@ -169,11 +173,12 @@ suite('e2e/evaluations', () => {
 
       const detail = client.evaluationDetails(FEATURE_ID_JSON)
       expect(detail).toBeEvaluation({
-        id: 'feature-js-e2e-json:2:bucketeer-js-user-id-1',
+        id: 'feature-js-e2e-json:3:bucketeer-js-user-id-1',
         featureId: FEATURE_ID_JSON,
-        featureVersion: 2,
+        featureVersion: 3,
         userId: USER_ID,
         variationId: '8b53a27b-2658-4f8c-925e-fb277808ed30',
+        variationName: 'variation 1',
         variationValue: `{ "key": "value-1" }`,
         reason: 'DEFAULT',
       })

--- a/src/BKTClient.ts
+++ b/src/BKTClient.ts
@@ -131,6 +131,7 @@ export class BKTClientImpl implements BKTClient {
         featureVersion: raw.featureVersion,
         userId: raw.userId,
         variationId: raw.variationId,
+        variationName: raw.variationName,
         variationValue: raw.variationValue,
         reason: raw.reason.type,
       } satisfies BKTEvaluation

--- a/src/BKTEvaluation.ts
+++ b/src/BKTEvaluation.ts
@@ -4,6 +4,7 @@ export interface BKTEvaluation {
   readonly featureVersion: number
   readonly userId: string
   readonly variationId: string
+  readonly variationName: string
   readonly variationValue: string
   readonly reason:
     | 'TARGET'

--- a/src/internal/model/Evaluation.ts
+++ b/src/internal/model/Evaluation.ts
@@ -1,5 +1,4 @@
 import { Reason } from './Reason'
-import { Variation } from './Variation'
 
 export interface Evaluation {
   id: string
@@ -7,7 +6,7 @@ export interface Evaluation {
   featureVersion: number
   userId: string
   variationId: string
-  variation: Variation
-  reason: Reason
+  variationName: string
   variationValue: string
+  reason: Reason
 }

--- a/src/internal/model/Variation.ts
+++ b/src/internal/model/Variation.ts
@@ -1,6 +1,0 @@
-export interface Variation {
-  id: string
-  value: string
-  name?: string
-  description?: string
-}

--- a/test/BKTClient.spec.ts
+++ b/test/BKTClient.spec.ts
@@ -595,10 +595,6 @@ suite('BKTClient', () => {
       const updatedEvaluation1 = {
         ...evaluation1,
         variationValue: 'updated_evaluation_value',
-        variation: {
-          ...evaluation1.variation,
-          value: 'updated_evaluation_value',
-        },
       } satisfies Evaluation
 
       server.use(
@@ -846,6 +842,7 @@ suite('BKTClient', () => {
         userId: user1.id,
         reason: evaluation1.reason.type,
         variationId: evaluation1.variationId,
+        variationName: evaluation1.variationName,
         variationValue: evaluation1.variationValue,
       })
     })
@@ -887,13 +884,10 @@ function buildEvaluation(value: string): Evaluation {
     id: 'evaluation_id_value',
     featureId: 'feature_id_value',
     featureVersion: 1,
-    variationId: 'variation_id_value',
     userId: user1.id,
+    variationId: 'variation_id_value',
+    variationName: 'variation_name_value',
     variationValue: value,
-    variation: {
-      id: 'variation_id_value',
-      value,
-    },
     reason: {
       type: 'CLIENT',
     },

--- a/test/mocks/evaluations.ts
+++ b/test/mocks/evaluations.ts
@@ -7,11 +7,8 @@ export const evaluation1 = {
   featureVersion: 9,
   userId: 'user_id_1',
   variationId: 'test-feature-1-variation-A',
+  variationName: 'test variation name1',
   variationValue: 'test variation value1',
-  variation: {
-    id: 'test-feature-1-variation-A',
-    value: 'test variation value1',
-  },
   reason: {
     type: 'CLIENT',
   },
@@ -23,11 +20,8 @@ export const evaluation2 = {
   featureVersion: 9,
   userId: 'user_id_1',
   variationId: 'test-feature-2-variation-A',
+  variationName: 'test variation name2',
   variationValue: 'test variation value2',
-  variation: {
-    id: 'test-feature-2-variation-A',
-    value: 'test variation value2',
-  },
   reason: {
     type: 'CLIENT',
   },
@@ -39,11 +33,8 @@ export const evaluation3 = {
   featureVersion: 9,
   userId: 'user_id_2',
   variationId: 'test-feature-1-variation-A',
+  variationName: 'test variation name2',
   variationValue: 'test variation value2',
-  variation: {
-    id: 'test-feature-1-variation-A',
-    value: 'test variation value2',
-  },
   reason: {
     type: 'CLIENT',
   },


### PR DESCRIPTION
Things done.

- Removed the deprecated Variation object
- Added the variation name to the BKTEvaluation object
- Updated e2e tests