### PR TITLE
ci: update renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,26 @@
     ":pinDevDependencies",
     "schedule:monthly"
   ],
+  "labels": ["deps"],
   "lockFileMaintenance": {
     "enabled": true
   },
   "packageRules": [
     {
+      "managers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "labels": ["ci"],
+      "commitMessagePrefix": "ci:",
+      "commitMessageAction": "update",
+      "groupName": "github-actions"
+    },
+    {
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
-      "commitMessagePrefix": "build(deps)",
+      "commitMessagePrefix": "build(deps):",
+      "commitMessageAction": "update",
       "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
+      "groupSlug": "all-minor-patch dependencies",
       "excludePackageNames": [
         "@vitest/browser",
         "@vitest/utils",
@@ -31,7 +41,8 @@
         "vitest",
         "webdriverio"
       ],
-      "commitMessagePrefix": "build(deps)",
+      "commitMessagePrefix": "build(deps):",
+      "commitMessageAction": "update",
       "groupName": "vitest"
     }
   ]


### PR DESCRIPTION
### Things done

- Fixed PR's title failing when the PR is created
- Added rule for GitHub actions
- Added labels for build and ci updates