### PR TITLE
chore: change the event flush interval default setting

### DIFF
--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -3,8 +3,8 @@ import { BKTStorage, createBKTStorage } from './BKTStorage'
 import { FetchLike } from './internal/remote/fetch'
 import { SDK_VERSION } from './internal/version'
 
-const MINIMUM_FLUSH_INTERVAL_MILLIS = 60_000 // 60 seconds
-const DEFAULT_FLUSH_INTERVAL_MILLIS = 60_000 // 60 seconds
+const MINIMUM_FLUSH_INTERVAL_MILLIS = 30_000 // 30 seconds
+const DEFAULT_FLUSH_INTERVAL_MILLIS = 30_000 // 30 seconds
 const DEFAULT_MAX_QUEUE_SIZE = 50
 const MINIMUM_POLLING_INTERVAL_MILLIS = 60_000 // 60 seconds
 const DEFAULT_POLLING_INTERVAL_MILLIS = 600_000 // 10 minutes

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -19,7 +19,7 @@ suite('defineBKTConfig', () => {
 
     expect(result).toStrictEqual({
       ...defaultConfig,
-      eventsFlushInterval: 60_000,
+      eventsFlushInterval: 30_000,
       eventsMaxQueueSize: 50,
       pollingInterval: 600_000,
       storageKeyPrefix: '',
@@ -70,7 +70,7 @@ suite('defineBKTConfig', () => {
       eventsFlushInterval: 10,
     })
 
-    expect(result.eventsFlushInterval).toBe(60_000)
+    expect(result.eventsFlushInterval).toBe(30_000)
   })
 
   test('sooner pollingInterval should be replaced with default value', () => {


### PR DESCRIPTION
Because the JS SDK doesn't listen to events when the tab is closed, I'm changing the default event flush interval from 60 seconds to 30 seconds so the SDK will try to send the events as soon as possible, decreasing the chance of event loss.