### PR TITLE
fix: unable capture request error when got a response with status 200 and invalid JSON

### DIFF
--- a/test/internal/remote/ApiClient.spec.ts
+++ b/test/internal/remote/ApiClient.spec.ts
@@ -340,12 +340,12 @@ suite('internal/remote/ApiClient', () => {
       expect(response.type).toBe('failure')
 
       const error = response.error
-
       expect(error.name).toBe('UnknownException')
-      expect(error.type).toBe(MetricsEventType.UnknownError)
 
       const unknownException = error as UnknownException
       expect(unknownException.type).toBe(MetricsEventType.UnknownError)
+      expect(unknownException.statusCode).toBe(200)
+      expect(unknownException.message).contain('invaild JSON response')
     })
   })
 })

--- a/test/internal/remote/ApiClient.spec.ts
+++ b/test/internal/remote/ApiClient.spec.ts
@@ -324,7 +324,7 @@ suite('internal/remote/ApiClient', () => {
       expect(error.timeoutMillis).toBe(200)
     })
 
-    test('response status okay with invaild JSON response', async () => {
+    test('got a response with status 200 and invalid JSON', async () => {
       apiClient = new ApiClientImpl(endpoint, 'api_key_value', fetch, 200)
       server.use(
         rest.post(`${endpoint}/register_events`, async (_req, res, ctx) => {


### PR DESCRIPTION
### Changes
- [x] Capture error when parser JSON

refs: https://github.com/bucketeer-io/ios-client-sdk/pull/77/files#diff-cbe40a73c2775ae6d2ec397ae2386f798bfb68541dbc5ef1b6595d87b1fd8ca7R105