### PR TITLE
fix: change package.json to resolve the type definition file when `moduleResolution: bundler` is defined in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     ".": {
       "node": {
         "import": "./dist/main.mjs",
-        "require": "./dist/main.cjs"
+        "require": "./dist/main.cjs",
+        "types": "./dist/main.d.ts"
       },
       "default": {
         "import": "./dist/main.browser.mjs",
-        "require": "./dist/main.browser.cjs"
+        "require": "./dist/main.browser.cjs",
+        "types": "./dist/main.d.ts"
       }
     }
   },


### PR DESCRIPTION
When `moduleResolution: bundler` is defined in tsconfig.json, TypeScript finds the type definition from `exports` fields in package.json.

However, `exports` fields has no `types` fields, TypeScript cannot search the type definition.

This PR changes package.json to resolve the type definition when `moduleResolution: bundler` is defined in tsconfig.json.