### PR TITLE
fix: define the exception name explicitly

### DIFF
--- a/src/BKTExceptions.ts
+++ b/src/BKTExceptions.ts
@@ -4,16 +4,17 @@ import {
 } from './internal/model/MetricsEventData'
 
 abstract class BKTBaseException extends Error {
+  name = 'BKTBaseException'
   type?: ErrorMetricsEventType = undefined
   constructor(msg?: string) {
     super(msg)
-    this.name = new.target.name
     Object.setPrototypeOf(this, new.target.prototype)
   }
 }
 
 // server redirect 300..399
 export class RedirectRequestException extends BKTBaseException {
+  name = 'RedirectRequestException' as const
   type?: ErrorMetricsEventType = MetricsEventType.RedirectRequestError
   statusCode: number
 
@@ -26,43 +27,53 @@ export class RedirectRequestException extends BKTBaseException {
 // server errors ---
 // 400: Bad Request
 export class BadRequestException extends BKTBaseException {
+  name = 'BadRequestException' as const
   type?: ErrorMetricsEventType = MetricsEventType.BadRequestError
 }
 // 401: Unauthorized
 export class UnauthorizedException extends BKTBaseException {
+  name = 'UnauthorizedException' as const
   type?: ErrorMetricsEventType = MetricsEventType.UnauthorizedError
 }
 // 403: Forbidden
 export class ForbiddenException extends BKTBaseException {
+  name = 'ForbiddenException' as const
   type?: ErrorMetricsEventType = MetricsEventType.ForbiddenError
 }
 // 404: NotFound
 export class NotFoundException extends BKTBaseException {
+  name = 'NotFoundException' as const
   type?: ErrorMetricsEventType = MetricsEventType.NotFoundError
 }
 // 405: InvalidHttpMethod
 export class InvalidHttpMethodException extends BKTBaseException {
+  name = 'InvalidHttpMethodException' as const
   type?: ErrorMetricsEventType = MetricsEventType.InternalSdkError
 }
 // 413: Payload Too Large
 export class PayloadTooLargeException extends BKTBaseException {
+  name = 'PayloadTooLargeException' as const
   type?: ErrorMetricsEventType = MetricsEventType.PayloadTooLargeError
 }
 // 499: Client Closed Request
 export class ClientClosedRequestException extends BKTBaseException {
+  name = 'ClientClosedRequestException' as const
   type?: ErrorMetricsEventType = MetricsEventType.ClientClosedRequestError
 }
 // 500: Internal Server Error
 export class InternalServerErrorException extends BKTBaseException {
+  name = 'InternalServerErrorException' as const
   type?: ErrorMetricsEventType = MetricsEventType.InternalServerError
 }
 // 502, 503, 504: Service Unavailable
 export class ServiceUnavailableException extends BKTBaseException {
+  name = 'ServiceUnavailableException' as const
   type?: ErrorMetricsEventType = MetricsEventType.ServiceUnavailableError
 }
 
 // network errors
 export class TimeoutException extends BKTBaseException {
+  name = 'TimeoutException' as const
   type?: ErrorMetricsEventType = MetricsEventType.TimeoutError
   timeoutMillis: number
 
@@ -72,15 +83,21 @@ export class TimeoutException extends BKTBaseException {
   }
 }
 export class NetworkException extends BKTBaseException {
+  name = 'NetworkException' as const
   type?: ErrorMetricsEventType = MetricsEventType.NetworkError
 }
 
 // sdk errors
-export class IllegalArgumentException extends BKTBaseException {}
-export class IllegalStateException extends BKTBaseException {}
+export class IllegalArgumentException extends BKTBaseException {
+  name = 'IllegalArgumentException' as const
+}
+export class IllegalStateException extends BKTBaseException {
+  name = 'IllegalStateException' as const
+}
 
 // unknown errors
 export class UnknownException extends BKTBaseException {
+  name = 'UnknownException' as const
   type?: ErrorMetricsEventType = MetricsEventType.UnknownError
   statusCode?: number
 


### PR DESCRIPTION
If the code is minified, new.target.name will also be minified, making it difficult to collect error logs.

Therefore, the name property of the Exception should be explicitly given the Exception name as a string so that it is not affected by minify.