### PR TITLE
feat: distribute sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "unbuild",
+    "build": "unbuild --sourcemap",
     "preview": "vite preview",
     "test": "pnpm test:browser --run ; pnpm test:node --run",
     "test:browser": "vitest --config ./vitest-browser.config.ts --dir test",


### PR DESCRIPTION
Distribute sourcemap for easy debugging by library users.

The sourcemap file is exported as a separate file, so users who do not use the sourcemap will not be affected by the change.