### PR TITLE
test: skip feature version checking in the e2e tests

### DIFF
--- a/e2e/assertions.ts
+++ b/e2e/assertions.ts
@@ -6,7 +6,6 @@ expect.extend({
       actual != null &&
       actual.id === expected.id &&
       actual.featureId === expected.featureId &&
-      actual.featureVersion === expected.featureVersion &&
       actual.userId === expected.userId &&
       actual.variationId === expected.variationId &&
       actual.variationName === expected.variationName &&


### PR DESCRIPTION
This PR removed the feature version from the checking to avoid future issues when editing the flags on the admin console