### PR TITLE
chore: change BTKStorage interface to be async

### DIFF
--- a/e2e/BKTClient.spec.ts
+++ b/e2e/BKTClient.spec.ts
@@ -118,7 +118,7 @@ suite('e2e/BKTClientTest', () => {
         client,
       ).dataModule.evaluationStorage() as EvaluationStorageImpl
 
-      const current = evaluationStorage.storage.get()
+      const current = await evaluationStorage.storage.get()
 
       assert(current != null)
 
@@ -129,14 +129,14 @@ suite('e2e/BKTClientTest', () => {
         .toString()
 
       // update evaluations manually, and check if evaluation1 is deleted after fetchEvaluations
-      evaluationStorage.storage.set({
+      await evaluationStorage.storage.set({
         ...current,
         evaluations: { [evaluation1.featureId]: evaluation1 },
         currentEvaluationsId: randomEvaluationsId,
         evaluatedAt: '1',
       })
 
-      const testTarget = evaluationStorage.storage.get()
+      const testTarget = await evaluationStorage.storage.get()
 
       assert(testTarget != null)
 
@@ -147,7 +147,7 @@ suite('e2e/BKTClientTest', () => {
 
       await client.fetchEvaluations()
 
-      const updated = evaluationStorage.storage.get()
+      const updated = await evaluationStorage.storage.get()
 
       assert(updated != null)
 
@@ -164,18 +164,18 @@ suite('e2e/BKTClientTest', () => {
         client,
       ).dataModule.evaluationStorage() as EvaluationStorageImpl
 
-      const current = evaluationStorage.storage.get()
+      const current = await evaluationStorage.storage.get()
 
       assert(current != null)
 
       // update evaluations manually, and check if evaluation1 is deleted after fetchEvaluations
-      evaluationStorage.storage.set({
+      await evaluationStorage.storage.set({
         ...current,
         evaluations: { [evaluation1.featureId]: evaluation1 },
         currentEvaluationsId: null,
       })
 
-      const testTarget = evaluationStorage.storage.get()
+      const testTarget = await evaluationStorage.storage.get()
 
       assert(testTarget != null)
 
@@ -186,7 +186,7 @@ suite('e2e/BKTClientTest', () => {
 
       await client.fetchEvaluations()
 
-      const updated = evaluationStorage.storage.get()
+      const updated = await evaluationStorage.storage.get()
 
       assert(updated != null)
 

--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -65,11 +65,11 @@ suite('e2e/events', () => {
 
     assert(client != null)
 
-    client.track(GOAL_ID, GOAL_VALUE)
+    await client.track(GOAL_ID, GOAL_VALUE)
 
     const component = getDefaultComponent(client)
 
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
     expect(events).toHaveLength(3)
     expect(
       events.some(
@@ -81,7 +81,7 @@ suite('e2e/events', () => {
     ).toBe(true)
     await client.flush()
 
-    expect(component.dataModule.eventStorage().getAll()).toHaveLength(0)
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
   })
 
   test('evaluation event', async () => {
@@ -102,7 +102,7 @@ suite('e2e/events', () => {
 
     const component = getDefaultComponent(client)
 
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
     // It includes the Latency and ResponseSize metrics
     expect(events).toHaveLength(8)
     expect(
@@ -116,7 +116,7 @@ suite('e2e/events', () => {
 
     await client.flush()
 
-    expect(component.dataModule.eventStorage().getAll()).toHaveLength(0)
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
   })
 
   test('default evaluation event', async () => {
@@ -126,7 +126,9 @@ suite('e2e/events', () => {
 
     // clear event storage to mimic no-cache state
     const component = getDefaultComponent(client)
-    component.dataModule.evaluationStorage().clear()
+    await component.dataModule.evaluationStorage().clear()
+    // load cache
+    await component.dataModule.evaluationStorage().initialize()
 
     expect(client.stringVariation(FEATURE_ID_STRING, 'value-default')).toBe(
       'value-default',
@@ -145,7 +147,7 @@ suite('e2e/events', () => {
       key: 'value-default',
     })
 
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
     // It includes the Latency and ResponseSize metrics
     expect(events).toHaveLength(8)
     expect(
@@ -157,7 +159,7 @@ suite('e2e/events', () => {
 
     await client.flush()
 
-    expect(component.dataModule.eventStorage().getAll()).toHaveLength(0)
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
   })
 
   suite('MetricsEvent', () => {
@@ -207,7 +209,7 @@ suite('e2e/events', () => {
       assert(client != null)
       const component = getDefaultComponent(client)
 
-      const events = component.dataModule.eventStorage().getAll()
+      const events = await component.dataModule.eventStorage().getAll()
 
       expect(events).toHaveLength(0)
       expect(
@@ -224,7 +226,7 @@ suite('e2e/events', () => {
 
       await client.flush()
 
-      const events2 = component.dataModule.eventStorage().getAll()
+      const events2 = await component.dataModule.eventStorage().getAll()
 
       // no events should be stored
       expect(events2).toHaveLength(0)
@@ -246,7 +248,7 @@ suite('e2e/events', () => {
       assert(client2 != null)
       const component2 = getDefaultComponent(client)
 
-      const events3 = component2.dataModule.eventStorage().getAll()
+      const events3 = await component2.dataModule.eventStorage().getAll()
       // 2 events - latency and response size
       expect(events3).toHaveLength(2)
       // ForbiddenError should not exist
@@ -264,7 +266,7 @@ suite('e2e/events', () => {
 
       await client2.flush()
 
-      const events4 = component2.dataModule.eventStorage().getAll()
+      const events4 = await component2.dataModule.eventStorage().getAll()
 
       // error from /register_events does not get stored
       expect(events4).toHaveLength(0)
@@ -315,7 +317,7 @@ suite('e2e/events', () => {
       assert(client != null)
       const component = getDefaultComponent(client)
 
-      const events = component.dataModule.eventStorage().getAll()
+      const events = await component.dataModule.eventStorage().getAll()
 
       expect(events).toHaveLength(1)
       expect(
@@ -332,7 +334,7 @@ suite('e2e/events', () => {
 
       await client.flush()
 
-      const events2 = component.dataModule.eventStorage().getAll()
+      const events2 = await component.dataModule.eventStorage().getAll()
       expect(events2).toHaveLength(0)
     })
   })

--- a/e2e/wrapperSdkSourceId.spec.ts
+++ b/e2e/wrapperSdkSourceId.spec.ts
@@ -66,11 +66,11 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
 
     assert(client != null)
 
-    client.track(GOAL_ID, GOAL_VALUE)
+    await client.track(GOAL_ID, GOAL_VALUE)
 
     const component = getDefaultComponent(client)
 
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
     expect(events).toHaveLength(3)
     expect(
       events.some(
@@ -82,7 +82,7 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
     ).toBe(true)
     await client.flush()
 
-    expect(component.dataModule.eventStorage().getAll()).toHaveLength(0)
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
   })
 
   test('evaluation event', async () => {
@@ -102,8 +102,7 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
     })
 
     const component = getDefaultComponent(client)
-
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
     // It includes the Latency and ResponseSize metrics
     expect(events).toHaveLength(8)
     expect(
@@ -117,7 +116,7 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
 
     await client.flush()
 
-    expect(component.dataModule.eventStorage().getAll()).toHaveLength(0)
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
   })
 
   test('metrics event', async () => {
@@ -148,7 +147,7 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
     assert(client != null)
     const component = getDefaultComponent(client)
 
-    const events = component.dataModule.eventStorage().getAll()
+    const events = await component.dataModule.eventStorage().getAll()
 
     expect(events).toHaveLength(1)
     expect(
@@ -165,7 +164,7 @@ suite('e2e/wrapper-sdk-source-id-and-version', () => {
 
     await client.flush()
 
-    const events2 = component.dataModule.eventStorage().getAll()
+    const events2 = await component.dataModule.eventStorage().getAll()
     expect(events2).toHaveLength(0)
   })
 })

--- a/example/index.html
+++ b/example/index.html
@@ -10,8 +10,9 @@
   <div id="app">
     <button id="track_goal" type="button" disabled>track goal event</button>
     <button id="flush" type="button" disabled>flush events</button>
+    <button id="set_user_attributes" type="button">set user attributes</button>
+    <button id="view_user_attributes" type="button"> view user attributes</button>
     <div id="logs" style="border: 1px solid black; margin-top: 8px;"></div>
-
   </div>
   <script type="module">
     import start from './index.ts'

--- a/example/index.ts
+++ b/example/index.ts
@@ -14,6 +14,9 @@ export default async function start(root: HTMLElement) {
   const logsEl = root.querySelector('#logs')
   const buttonEl = root.querySelector('#track_goal')
   const flushEl = root.querySelector('#flush')
+  const setUserAttributesEl = root.querySelector('#set_user_attributes')
+  const viewUserAttributesEl = root.querySelector('#view_user_attributes')
+
   let listenerId: string | null | undefined = null
 
   function log(message: string) {
@@ -37,6 +40,24 @@ export default async function start(root: HTMLElement) {
       flushPromise
         .then(() => log('flushed'))
         .catch((error) => log(`flush failed: ${error}`))
+    }
+  })
+
+  setUserAttributesEl?.addEventListener('click', () => {
+    const client = getBKTClient()
+    if (client) {
+      // you can set custom attributes for the user
+      client.updateUserAttributes({ kYear: 'value_2025' })
+      log('user attributes set')
+    }
+  })
+
+  viewUserAttributesEl?.addEventListener('click', () => {
+    const client = getBKTClient()
+    if (client) {
+      // you can view current user attributes
+      const user = client.currentUser()
+      log(`current user attributes: ${JSON.stringify(user.attributes)}`)
     }
   })
 
@@ -91,8 +112,4 @@ export default async function start(root: HTMLElement) {
     const value = client?.stringVariation(STRING_FEATURE_ID, 'default_value')
     log(`value for feature_id: ${value}`)
   })
-
-  const value = client?.stringVariation(STRING_FEATURE_ID, 'default_value')
-
-  log(`value for feature_id: ${value}`)
 }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "vitest": "3.2.4",
     "webdriverio": "9.16.2"
   },
-  "packageManager": "pnpm@10.12.4"
+  "packageManager": "pnpm@10.12.4",
+  "dependencies": {
+    "async-mutex": "0.5.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      async-mutex:
+        specifier: 0.5.0
+        version: 0.5.0
     devDependencies:
       '@types/jsdom':
         specifier: 21.1.7
@@ -998,6 +1002,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -4050,6 +4057,10 @@ snapshots:
       tslib: 2.8.1
 
   async-function@1.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
 
   async@3.2.6: {}
 

--- a/src/BKTStorage.ts
+++ b/src/BKTStorage.ts
@@ -2,19 +2,19 @@ export const keyname = (prefix: string, key: string): string =>
   `${prefix}_${key}`
 
 export interface BKTStorage<T> {
-  set(value: T | null): void
-  get(): T | null
-  clear(): void
+  set(value: T | null): Promise<void>
+  get(): Promise<T | null>
+  clear(): Promise<void>
 }
 
 export class BrowserLocalStorage<T> implements BKTStorage<T> {
   constructor(private key: string) {}
 
-  public set<T>(value: T | null) {
+  public async set(value: T | null) {
     localStorage.setItem(this.key, JSON.stringify(value))
   }
 
-  public get<T>(): T | null {
+  public async get(): Promise<T | null> {
     const result = localStorage.getItem(this.key)
     if (result === null) {
       return null
@@ -22,7 +22,7 @@ export class BrowserLocalStorage<T> implements BKTStorage<T> {
     return JSON.parse(result) as T
   }
 
-  public clear() {
+  public async clear() {
     localStorage.removeItem(this.key)
   }
 }
@@ -32,15 +32,15 @@ export class InMemoryStorage<T> implements BKTStorage<T> {
 
   constructor(private key: string) {}
 
-  set(value: T | null): void {
+  async set(value: T | null) {
     this.cache[this.key] = value
   }
 
-  get(): T | null {
+  async get(): Promise<T | null> {
     return this.cache[this.key] ?? null
   }
 
-  clear(): void {
+  async clear() {
     delete this.cache[this.key]
   }
 }

--- a/src/internal/evaluation/EvaluationInteractor.ts
+++ b/src/internal/evaluation/EvaluationInteractor.ts
@@ -11,29 +11,37 @@ export class EvaluationInteractor {
     private apiClient: ApiClient,
     private evaluationStorage: EvaluationStorage,
     private idGenerator: IdGenerator,
-  ) {
-    // check if the new featureTag is different from the saved one
-    this.evaluationStorage.updateFeatureTag(this.featureTag)
-  }
+  ) {}
 
   // visible for testing. should only be accessed from test code
   updateListeners: Record<string, () => void> = {}
+
+  // Important: should call this method before using the interactor.
+  async initialize(): Promise<void> {
+    // This method is used to initialize the interactor internally.
+    // It can be used to perform any setup required before using the interactor.
+    await this.evaluationStorage.initialize()
+    // check if the new featureTag is different from the saved one
+    // If the featureTag is different, update it in the storage and clear currentEvaluationsId
+    await this.evaluationStorage.updateFeatureTag(this.featureTag)
+  }
 
   async fetch(
     user: User,
     timeoutMillis?: number,
   ): Promise<GetEvaluationsResult> {
     const currentEvaluationsId =
-      this.evaluationStorage.getCurrentEvaluationsId() ?? ''
-
+      await this.evaluationStorage.getCurrentEvaluationsId() ?? ''
+    const evaluatedAt = await this.evaluationStorage.getEvaluatedAt() ?? '0'
+    const userAttributesUpdated = await
+            this.evaluationStorage.getUserAttributesUpdated()
     const result = await this.apiClient.getEvaluations(
       {
         user,
         userEvaluationsId: currentEvaluationsId,
         userEvaluationCondition: {
-          evaluatedAt: this.evaluationStorage.getEvaluatedAt() ?? '0',
-          userAttributesUpdated:
-            this.evaluationStorage.getUserAttributesUpdated(),
+          evaluatedAt: evaluatedAt,
+          userAttributesUpdated: userAttributesUpdated,
         },
         tag: this.featureTag,
       },
@@ -47,7 +55,7 @@ export class EvaluationInteractor {
       if (response.evaluations.forceUpdate) {
         // 1- Delete all the evaluations from local storage, and save the latest evaluations from the response into the local storage
         // 2- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the localStorage
-        this.evaluationStorage.deleteAllAndInsert(
+        await this.evaluationStorage.deleteAllAndInsert(
           response.userEvaluationsId,
           response.evaluations.evaluations ?? [],
           response.evaluations.createdAt,
@@ -57,7 +65,7 @@ export class EvaluationInteractor {
         // 1- Check the evaluation list in the response and upsert them in the localStorage if the list is not empty
         // 2- Check the archivedFeatureIds list and delete them from the localStorage if is not empty
         // 3- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the localStorage
-        shouldNotify = this.evaluationStorage.update(
+        shouldNotify = await this.evaluationStorage.update(
           response.userEvaluationsId,
           response.evaluations.evaluations ?? [],
           response.evaluations.archivedFeatureIds ?? [],
@@ -65,7 +73,7 @@ export class EvaluationInteractor {
         )
       }
 
-      this.evaluationStorage.clearUserAttributesUpdated()
+      await this.evaluationStorage.clearUserAttributesUpdated()
 
       if (shouldNotify) {
         Object.values(this.updateListeners).forEach((listener) => listener())
@@ -79,8 +87,8 @@ export class EvaluationInteractor {
     return this.evaluationStorage.getByFeatureId(featureId)
   }
 
-  setUserAttributesUpdated(): void {
-    this.evaluationStorage.setUserAttributesUpdated()
+  async setUserAttributesUpdated(): Promise<void> {
+    return this.evaluationStorage.setUserAttributesUpdated()
   }
 
   addUpdateListener(listener: () => void): string {

--- a/src/internal/evaluation/EvaluationStorage.ts
+++ b/src/internal/evaluation/EvaluationStorage.ts
@@ -1,5 +1,7 @@
 import { Evaluation } from '../model/Evaluation'
 import { BKTStorage } from '../../BKTStorage'
+import { Mutex } from 'async-mutex'
+import { runWithMutex } from '../mutex'
 
 export interface EvaluationEntity {
   userId: string
@@ -13,152 +15,207 @@ export interface EvaluationEntity {
 export interface EvaluationStorage {
   getByFeatureId(featureId: string): Evaluation | null
 
+  /**
+   * Preload the storage from the underlying storage.
+   * This is useful to ensure that the storage is ready before any operations.
+   */
+  initialize(): Promise<void>
+
   deleteAllAndInsert(
     evaluationsId: string,
     evaluations: Evaluation[],
     evaluatedAt: string,
-  ): void
+  ): Promise<void>
   update(
     evaluationsId: string,
     evaluations: Evaluation[],
     archivedFeatureIds: string[],
     evaluatedAt: string,
-  ): boolean
+  ): Promise<boolean>
 
-  getCurrentEvaluationsId(): string | null
+  getCurrentEvaluationsId(): Promise<string | null>
 
-  getEvaluatedAt(): string | null
+  getEvaluatedAt(): Promise<string | null>
 
   /**
    * @returns true if featureTag has been updated
    */
-  updateFeatureTag(featureTag: string): boolean
+  updateFeatureTag(featureTag: string): Promise<boolean>
 
-  setUserAttributesUpdated(): void
-  getUserAttributesUpdated(): boolean
-  clearUserAttributesUpdated(): void
+  setUserAttributesUpdated(): Promise<void>
+  getUserAttributesUpdated(): Promise<boolean>
+  clearUserAttributesUpdated(): Promise<void>
 
-  clear(): void
+  clear(): Promise<void>
 }
 
 export class EvaluationStorageImpl implements EvaluationStorage {
   constructor(
     public userId: string,
     public storage: BKTStorage<EvaluationEntity>,
-  ) {}
+  ) { }
+  
+  private mutex = new Mutex()
+
+  /**
+   * Cached evaluation entity for fast access.
+   * It is initialized to null, meaning that the storage has not been loaded yet.
+   * It is set to null when the storage is cleared.
+   */
+  public cacheEvaluationEntity: EvaluationEntity | null = null
+
+  async initialize(): Promise<void> {
+    if (this.cacheEvaluationEntity) {
+      throw new Error(
+        'Evaluation storage is already initialized. Call clear() to reset.',
+      )
+    }
+    this.cacheEvaluationEntity = await this.getInternal(this.userId)
+  }
+
+  private getCachedEvaluationEntity(): EvaluationEntity {
+    if (this.cacheEvaluationEntity === null) {
+      throw new Error(
+        'Cache Evaluation entity is not loaded. Call initialize() first.',
+      )
+    }
+    return this.cacheEvaluationEntity
+  }
+
+  /**
+   * Save the evaluation entity to the storage.
+   * Also updates the cached entity.
+   */
+  private async saveAsync(entity: EvaluationEntity): Promise<void> {
+    this.cacheEvaluationEntity = entity
+    await this.storage.set(entity)
+  }
 
   getByFeatureId(featureId: string): Evaluation | null {
-    const entity = this.getInternal(this.userId)
+    const entity = this.getCachedEvaluationEntity()
     return entity.evaluations[featureId] ?? null
   }
 
-  deleteAllAndInsert(
+  async deleteAllAndInsert(
     evaluationsId: string,
     evaluations: Evaluation[],
     evaluatedAt: string,
-  ): void {
-    const entity = this.getInternal(this.userId)
-    const updated: EvaluationEntity = {
-      ...entity,
-      userId: this.userId,
-      currentEvaluationsId: evaluationsId,
-      evaluations: evaluations.reduce<EvaluationEntity['evaluations']>(
-        (acc, cur) => {
-          return { ...acc, [cur.featureId]: cur }
-        },
-        {},
-      ),
-      evaluatedAt,
-    }
-
-    this.storage.set(updated)
+  ): Promise<void> {
+    await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
+      const updated: EvaluationEntity = {
+        ...entity,
+        userId: this.userId,
+        currentEvaluationsId: evaluationsId,
+        evaluations: evaluations.reduce<EvaluationEntity['evaluations']>(
+          (acc, cur) => {
+            return { ...acc, [cur.featureId]: cur }
+          },
+          {},
+        ),
+        evaluatedAt,
+      }
+      await this.saveAsync(updated)
+    })
   }
 
-  update(
+  async update(
     evaluationsId: string,
     evaluations: Evaluation[],
     archivedFeatureIds: string[],
     evaluatedAt: string,
-  ): boolean {
-    const entity = this.getInternal(this.userId)
+  ): Promise<boolean> {
+    return await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
 
-    // remove archived evaluations
-    const activeEvaluations = Object.fromEntries(
-      Object.entries(entity.evaluations).filter(
-        ([key]) => !archivedFeatureIds.includes(key),
-      ),
-    )
+      // remove archived evaluations
+      const activeEvaluations = Object.fromEntries(
+        Object.entries(entity.evaluations).filter(
+          ([key]) => !archivedFeatureIds.includes(key),
+        ),
+      )
 
-    // update/add evaluations
-    evaluations.forEach((ev) => {
-      activeEvaluations[ev.featureId] = ev
-    })
-
-    this.storage.set({
-      ...entity,
-      currentEvaluationsId: evaluationsId,
-      evaluations: activeEvaluations,
-      evaluatedAt,
-    })
-
-    return (
-      entity.currentEvaluationsId !== evaluationsId ||
-      evaluations.length > 0 ||
-      archivedFeatureIds.length > 0
-    )
-  }
-
-  getCurrentEvaluationsId(): string | null {
-    return this.getInternal(this.userId).currentEvaluationsId
-  }
-
-  getEvaluatedAt(): string | null {
-    return this.getInternal(this.userId).evaluatedAt
-  }
-
-  updateFeatureTag(featureTag: string): boolean {
-    const entity = this.getInternal(this.userId)
-    const changed = entity.currentFeatureTag !== featureTag
-
-    if (changed) {
-      this.storage.set({
-        ...entity,
-        currentFeatureTag: featureTag,
-        currentEvaluationsId: null,
+      // update/add evaluations
+      evaluations.forEach((ev) => {
+        activeEvaluations[ev.featureId] = ev
       })
-    }
 
-    return changed
-  }
+      await this.saveAsync({
+        ...entity,
+        currentEvaluationsId: evaluationsId,
+        evaluations: activeEvaluations,
+        evaluatedAt,
+      })
 
-  setUserAttributesUpdated(): void {
-    const entity = this.getInternal(this.userId)
-
-    this.storage.set({
-      ...entity,
-      userAttributesUpdated: true,
+      return (
+        entity.currentEvaluationsId !== evaluationsId ||
+        evaluations.length > 0 ||
+        archivedFeatureIds.length > 0
+      )
     })
   }
 
-  getUserAttributesUpdated(): boolean {
-    return this.getInternal(this.userId).userAttributesUpdated
+  async getCurrentEvaluationsId(): Promise<string | null> {
+    return this.getCachedEvaluationEntity().currentEvaluationsId
   }
 
-  clearUserAttributesUpdated(): void {
-    const entity = this.getInternal(this.userId)
+  async getEvaluatedAt(): Promise<string | null> {
+    return this.getCachedEvaluationEntity().evaluatedAt
+  }
 
-    this.storage.set({
-      ...entity,
-      userAttributesUpdated: false,
+  async updateFeatureTag(featureTag: string): Promise<boolean> {
+    return await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
+      const changed = entity.currentFeatureTag !== featureTag
+
+      if (changed) {
+        await this.saveAsync({
+          ...entity,
+          currentFeatureTag: featureTag,
+          currentEvaluationsId: null,
+        })
+      }
+
+      return changed
     })
   }
 
-  clear(): void {
-    this.storage.clear()
+  async setUserAttributesUpdated(): Promise<void> {
+    await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
+      await this.saveAsync({
+        ...entity,
+        userAttributesUpdated: true,
+      })
+    })
   }
 
-  private getInternal(userId: string): EvaluationEntity {
-    const entity = this.storage.get()
+  async getUserAttributesUpdated(): Promise<boolean> {
+    return await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
+      return entity.userAttributesUpdated
+    })
+  }
+
+  async clearUserAttributesUpdated(): Promise<void> {
+    await runWithMutex(this.mutex, async () => {
+      const entity = this.getCachedEvaluationEntity()
+      await this.saveAsync({
+        ...entity,
+        userAttributesUpdated: false,
+      })
+    })
+  }
+
+  async clear(): Promise<void> {
+    await runWithMutex(this.mutex, async () => {
+      await this.storage.clear()
+      this.cacheEvaluationEntity = null
+    })
+  }
+
+  private async getInternal(userId: string): Promise<EvaluationEntity> {
+    const entity = await this.storage.get()
     if (!entity || entity.userId !== userId) {
       // entity doesn't exist or userId is different
       return {

--- a/src/internal/mutex.ts
+++ b/src/internal/mutex.ts
@@ -1,0 +1,20 @@
+import { Mutex } from 'async-mutex'
+
+async function runWithMutex<T>(
+  mutex: Mutex,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let release: (() => void) | undefined
+  try {
+    release = await mutex.acquire()
+    return await fn()
+  } catch (error) {
+    throw error
+  } finally {
+    release?.()
+  }
+}
+
+export {
+  runWithMutex
+}

--- a/test/internal/event/EventStorage.spec.ts
+++ b/test/internal/event/EventStorage.spec.ts
@@ -25,39 +25,39 @@ suite('internal/event/EventStorage', () => {
   })
 
   suite('getAll', () => {
-    test('return events if saved data is present', () => {
-      storage.set({
+    test('return events if saved data is present', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [evaluationEvent1, goalEvent1],
       })
 
-      const result = eventStorage.getAll()
+      const result = await eventStorage.getAll()
 
       expect(result).toStrictEqual([evaluationEvent1, goalEvent1])
     })
 
-    test('return empty array if saved data is not present', () => {
-      storage.set({
+    test('return empty array if saved data is not present', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [],
       })
 
-      const result = eventStorage.getAll()
+      const result = await eventStorage.getAll()
 
       expect(result).toStrictEqual([])
     })
   })
 
   suite('add', () => {
-    test('add event to storage', () => {
-      storage.set({
+    test('add event to storage', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [goalEvent1],
       })
 
-      eventStorage.add(evaluationEvent1)
+      await eventStorage.add(evaluationEvent1)
 
-      expect(storage.get()?.events).toStrictEqual([
+      expect((await storage.get())?.events).toStrictEqual([
         goalEvent1,
         evaluationEvent1,
       ])
@@ -65,15 +65,15 @@ suite('internal/event/EventStorage', () => {
   })
 
   suite('addAll', () => {
-    test('add events to storage', () => {
-      storage.set({
+    test('add events to storage', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [goalEvent1],
       })
 
-      eventStorage.addAll([evaluationEvent1, evaluationEvent2])
+      await eventStorage.addAll([evaluationEvent1, evaluationEvent2])
 
-      expect(storage.get()?.events).toStrictEqual([
+      expect((await storage.get())?.events).toStrictEqual([
         goalEvent1,
         evaluationEvent1,
         evaluationEvent2,
@@ -82,28 +82,28 @@ suite('internal/event/EventStorage', () => {
   })
 
   suite('deleteByIds', () => {
-    test('delete events by ids', () => {
-      storage.set({
+    test('delete events by ids', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [evaluationEvent1, evaluationEvent2, goalEvent1],
       })
 
-      eventStorage.deleteByIds([evaluationEvent1.id, goalEvent1.id])
+      await eventStorage.deleteByIds([evaluationEvent1.id, goalEvent1.id])
 
-      expect(storage.get()?.events).toStrictEqual([evaluationEvent2])
+      expect((await storage.get())?.events).toStrictEqual([evaluationEvent2])
     })
   })
 
   suite('clear', () => {
-    test('clear events', () => {
-      storage.set({
+    test('clear events', async () => {
+      await storage.set({
         userId: 'user_id_1',
         events: [evaluationEvent1, evaluationEvent2, goalEvent1],
       })
 
-      eventStorage.clear()
+      await eventStorage.clear()
 
-      expect(storage.get()).toBeNull()
+      expect((await storage.get())).toBeNull()
     })
   })
 })

--- a/test/internal/scheduler/EvaluationTask.spec.ts
+++ b/test/internal/scheduler/EvaluationTask.spec.ts
@@ -22,6 +22,7 @@ import { user1Evaluations } from '../../mocks/evaluations'
 import { EvaluationTask } from '../../../src/internal/scheduler/EvaluationTask'
 import { GetEvaluationsRequest } from '../../../src/internal/model/request/GetEvaluationsRequest'
 import { GetEvaluationsResponse } from '../../../src/internal/model/response/GetEvaluationsResponse'
+import { requiredInternalConfig } from '../../../src/internal/InternalConfig'
 
 suite('internal/scheduler/EventTask', () => {
   let server: SetupServer
@@ -33,7 +34,7 @@ suite('internal/scheduler/EventTask', () => {
     server = setupServerAndListen()
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers()
 
     config = defineBKTConfig({
@@ -48,9 +49,11 @@ suite('internal/scheduler/EventTask', () => {
 
     component = new DefaultComponent(
       new TestPlatformModule(),
-      new DataModule(user1, config),
+      new DataModule(user1, requiredInternalConfig(config)),
       new InteractorModule(),
     )
+    // Initialize the evaluation interactor
+    await component.evaluationInteractor().initialize()
   })
 
   afterEach(() => {
@@ -190,16 +193,24 @@ suite('internal/scheduler/EventTask', () => {
           Record<string, never>,
           GetEvaluationsRequest,
           GetEvaluationsResponse
-        >(`${config.apiEndpoint}/get_evaluations`, () => {
-          return HttpResponse.json(null, { status: 500 })
-        }, { once: true }),
+        >(
+          `${config.apiEndpoint}/get_evaluations`,
+          () => {
+            return HttpResponse.json(null, { status: 500 })
+          },
+          { once: true },
+        ),
         http.post<
           Record<string, never>,
           GetEvaluationsRequest,
           GetEvaluationsResponse
-        >(`${config.apiEndpoint}/get_evaluations`, () => {
-          return HttpResponse.json(null, { status: 500 })
-        }, {once: true}),
+        >(
+          `${config.apiEndpoint}/get_evaluations`,
+          () => {
+            return HttpResponse.json(null, { status: 500 })
+          },
+          { once: true },
+        ),
         http.post<
           Record<string, never>,
           GetEvaluationsRequest,

--- a/test/internal/scheduler/EventTask.spec.ts
+++ b/test/internal/scheduler/EventTask.spec.ts
@@ -22,7 +22,8 @@ import { EventTask } from '../../../src/internal/scheduler/EventTask'
 import { TestPlatformModule, setupServerAndListen } from '../../utils'
 import { InteractorModule } from '../../../src/internal/di/InteractorModule'
 import { user1 } from '../../mocks/users'
-import { evaluation1, evaluation2 } from '../../mocks/evaluations'
+import { requiredInternalConfig } from '../../../src/internal/InternalConfig'
+import { ApiId } from '../../../src/internal/model/MetricsEventData'
 
 suite('internal/scheduler/EventTask', () => {
   let server: SetupServer
@@ -49,7 +50,7 @@ suite('internal/scheduler/EventTask', () => {
 
     component = new DefaultComponent(
       new TestPlatformModule(),
-      new DataModule(user1, config),
+      new DataModule(user1, requiredInternalConfig(config)),
       new InteractorModule(),
     )
   })
@@ -118,9 +119,10 @@ suite('internal/scheduler/EventTask', () => {
     task.start()
 
     const interactor = component.eventInteractor()
-    interactor.trackEvaluationEvent('feature_tag_value', user1, evaluation1)
-    interactor.trackEvaluationEvent('feature_tag_value', user1, evaluation2)
-    interactor.trackGoalEvent('feature_tag_value', user1, 'goal_id_value', 0.4)
+    // 1 event
+    await interactor.trackGoalEvent('feature_tag_value', user1, 'goal_id_value', 0.4)
+    // 2 events
+    await interactor.trackSuccess(ApiId.GET_EVALUATIONS, 'feature_tag_value', 1,1)
 
     expect(requestCount).toBe(0)
 


### PR DESCRIPTION
This PR refactors the storage layer to use asynchronous APIs with mutex protection and updates all dependent tests and client code to use async/await.

Convert BKTStorage interface and implementations to return Promise
Introduce runWithMutex helper and apply mutex locks in storage implementations
Update tests and client methods to await all asynchronous storage and interactor calls