### PR TITLE
fix: prevent undefined from overriding defaults in defineBKTConfig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run ESLint
-        run: pnpm lint
+        run:  |
+          pnpm lint
+          pnpm test:custom-eslint-rules
 
       - name: Run Tests for Browser environment
         run: pnpm test:browser

--- a/eslint-rules/no-spread-after-defaults.js
+++ b/eslint-rules/no-spread-after-defaults.js
@@ -27,22 +27,15 @@ export default {
               
               // Check for spread elements that might contain defaults
               if (prop.type === 'SpreadElement') {
-                const argName = prop.argument?.name || ''
-                
-                // Check if this spread element looks like it's spreading defaults
-                const isLikelyDefaultSpread = prop.argument && 
-                  prop.argument.type === 'Identifier' && 
-                  (/^(default|base|initial|fallback)/i.test(argName) ||
-                   /(default|base|initial)config$/i.test(argName))
-                
-                if (isLikelyDefaultSpread) {
-                  hasDefaultProperties = true
-                } else if (hasDefaultProperties) {
+                if (hasDefaultProperties) {
                   context.report({
                     node: prop,
                     message:
                       'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
                   })
+                } else {
+                  // Treat this spread element as a potential default for subsequent spreads
+                  hasDefaultProperties = true
                 }
               }
             }

--- a/eslint-rules/no-spread-after-defaults.js
+++ b/eslint-rules/no-spread-after-defaults.js
@@ -4,7 +4,8 @@ export default {
       meta: {
         type: 'problem',
         docs: {
-          description: 'Disallow spreading objects after default properties in object literals',
+          description:
+            'Disallow spreading objects after default properties in object literals',
           category: 'Possible Errors',
           recommended: false,
         },
@@ -20,17 +21,17 @@ export default {
               if (prop.type === 'Property' && !prop.computed) {
                 hasDefaultProperties = true
               }
-          if (
-            prop.type === 'SpreadElement' &&
-            hasDefaultProperties &&
-            prop.argument.type === 'Identifier' // Only flag spreading variables/identifiers
-          ) {
-            context.report({
-              node: prop,
-              message:
-                'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
-            })
-          }
+              if (
+                prop.type === 'SpreadElement' &&
+                hasDefaultProperties &&
+                prop.argument.type === 'Identifier' // Only flag spreading variables/identifiers
+              ) {
+                context.report({
+                  node: prop,
+                  message:
+                    'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+                })
+              }
             }
           },
         }

--- a/eslint-rules/no-spread-after-defaults.js
+++ b/eslint-rules/no-spread-after-defaults.js
@@ -1,0 +1,40 @@
+export default {
+  rules: {
+    'no-spread-after-defaults': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description: 'Disallow spreading objects after default properties in object literals',
+          category: 'Possible Errors',
+          recommended: false,
+        },
+        schema: [],
+      },
+      create(context) {
+        return {
+          ObjectExpression(node) {
+            const properties = node.properties
+            let hasDefaultProperties = false
+            for (let i = 0; i < properties.length; i++) {
+              const prop = properties[i]
+              if (prop.type === 'Property' && !prop.computed) {
+                hasDefaultProperties = true
+              }
+          if (
+            prop.type === 'SpreadElement' &&
+            hasDefaultProperties &&
+            prop.argument.type === 'Identifier' // Only flag spreading variables/identifiers
+          ) {
+            context.report({
+              node: prop,
+              message:
+                'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+            })
+          }
+            }
+          },
+        }
+      },
+    },
+  },
+}

--- a/eslint-rules/no-spread-after-defaults.js
+++ b/eslint-rules/no-spread-after-defaults.js
@@ -16,20 +16,34 @@ export default {
           ObjectExpression(node) {
             const properties = node.properties
             let hasDefaultProperties = false
+            
             for (let i = 0; i < properties.length; i++) {
               const prop = properties[i]
-              if (prop.type === 'Property' && !prop.computed) {
+              
+              // Consider all properties (computed, non-computed, methods) as defaults
+              if (prop.type === 'Property') {
                 hasDefaultProperties = true
               }
-              if (
-                prop.type === 'SpreadElement' &&
-                hasDefaultProperties
-              ) {
-                context.report({
-                  node: prop,
-                  message:
-                    'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
-                })
+              
+              // Check for spread elements that might contain defaults
+              if (prop.type === 'SpreadElement') {
+                const argName = prop.argument?.name || ''
+                
+                // Check if this spread element looks like it's spreading defaults
+                const isLikelyDefaultSpread = prop.argument && 
+                  prop.argument.type === 'Identifier' && 
+                  (/^(default|base|initial|fallback)/i.test(argName) ||
+                   /(default|base|initial)config$/i.test(argName))
+                
+                if (isLikelyDefaultSpread) {
+                  hasDefaultProperties = true
+                } else if (hasDefaultProperties) {
+                  context.report({
+                    node: prop,
+                    message:
+                      'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+                  })
+                }
               }
             }
           },

--- a/eslint-rules/no-spread-after-defaults.js
+++ b/eslint-rules/no-spread-after-defaults.js
@@ -23,8 +23,7 @@ export default {
               }
               if (
                 prop.type === 'SpreadElement' &&
-                hasDefaultProperties &&
-                prop.argument.type === 'Identifier' // Only flag spreading variables/identifiers
+                hasDefaultProperties
               ) {
                 context.report({
                   node: prop,

--- a/eslint-rules/no-spread-after-defaults.md
+++ b/eslint-rules/no-spread-after-defaults.md
@@ -1,0 +1,156 @@
+# Custom ESLint Rules
+
+## no-spread-after-defaults
+
+This rule prevents spreading objects after default properties in object literals to avoid unintentional override of defaults with `undefined` values.
+
+### Why this rule exists
+
+When you spread an object after defining default properties, any `undefined` values in the spread object will override your carefully set defaults. This can lead to subtle bugs where your fallback values are unexpectedly replaced with `undefined`.
+
+### Examples
+
+#### ✅ Allowed Cases
+
+**1. Spreading before any properties:**
+```javascript
+const obj = {
+  ...userOptions,     // Spread first
+  name: 'defaultName',
+  age: 25
+}
+```
+
+**2. Only properties (no spreading):**
+```javascript
+const obj = {
+  name: 'defaultName',
+  age: 25,
+  active: true
+}
+```
+
+**3. Empty object:**
+```javascript
+const obj = {}
+```
+
+#### ❌ Disallowed Cases
+
+**1. Spreading after regular properties:**
+```javascript
+const obj = {
+  name: 'defaultName',  // Default property
+  ...userOptions        // ❌ Could override with undefined
+}
+```
+
+**2. Spreading after computed properties:**
+```javascript
+const obj = {
+  [dynamicKey]: 'value',  // Default property
+  ...userOptions          // ❌ Could override with undefined
+}
+```
+
+**3. Spreading after methods:**
+```javascript
+const obj = {
+  getValue() { return 'default' },  // Default property
+  ...userOptions                    // ❌ Could override with undefined
+}
+```
+
+**4. Spreading after other spread elements:**
+```javascript
+const obj = {
+  ...baseConfig,    // Default property (spread)
+  ...userOptions    // ❌ Could override with undefined
+}
+```
+
+**5. Multiple consecutive spreads:**
+```javascript
+const obj = {
+  ...obj1,     // Default property
+  ...obj2,     // ❌ Flagged: comes after obj1
+  ...obj3      // ❌ Flagged: comes after obj1 and obj2
+}
+```
+
+### The Problem
+
+Consider this problematic code:
+```javascript
+// Dangerous: if userOptions.name is undefined, it overrides the default
+const config = {
+  name: 'defaultName',
+  timeout: 5000,
+  ...userOptions  // userOptions.name could be undefined!
+}
+
+// If userOptions = { name: undefined, retries: 3 }
+// Result: { name: undefined, timeout: 5000, retries: 3 }
+//         ^^^^^^^^^^^^^^^^^ Default was overridden!
+```
+
+### Better Alternatives
+
+**Option 1: Spread first, then set defaults**
+```javascript
+const config = {
+  ...userOptions,
+  name: userOptions.name ?? 'defaultName',
+  timeout: userOptions.timeout ?? 5000
+}
+```
+
+**Option 2: Use nullish coalescing**
+```javascript
+const config = {
+  name: userOptions.name ?? 'defaultName',
+  timeout: userOptions.timeout ?? 5000,
+  ...userOptions  // Only for non-conflicting properties
+}
+```
+
+**Option 3: Filter undefined values**
+```javascript
+const cleanOptions = Object.fromEntries(
+  Object.entries(userOptions).filter(([_, value]) => value !== undefined)
+)
+const config = {
+  name: 'defaultName',
+  timeout: 5000,
+  ...cleanOptions
+}
+```
+
+### When to disable this rule
+
+You can disable this rule when:
+
+1. **Type safety guarantees no undefined values** (like with TypeScript `Omit` types):
+```typescript
+// Safe: TypeScript ensures fields cannot contain BaseEvent properties
+const event = {
+  ...base,
+  // eslint-disable-next-line custom-rules/no-spread-after-defaults
+  ...fields,  // TypeScript guarantees no property conflicts
+  '@type': 'EvaluationEvent'
+}
+```
+
+2. **You explicitly want undefined to override defaults**:
+```javascript
+// Intentional: undefined should override defaults
+const config = {
+  enabled: true,
+  // eslint-disable-next-line custom-rules/no-spread-after-defaults
+  ...userSettings  // User can explicitly disable with undefined
+}
+```
+
+### Rule Configuration
+
+This rule has no configuration options. It will flag any spread element that appears after any property (regular, computed, method, or spread) in an object literal.

--- a/eslint-rules/no-spread-after-defaults.test.js
+++ b/eslint-rules/no-spread-after-defaults.test.js
@@ -1,0 +1,176 @@
+import { RuleTester } from 'eslint'
+import rule from './no-spread-after-defaults.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-spread-after-defaults', rule.rules['no-spread-after-defaults'], {
+  valid: [
+    // Empty object
+    {
+      code: 'const obj = {}',
+    },
+    
+    // Only properties
+    {
+      code: `const obj = {
+        name: 'defaultName',
+        age: 25,
+        active: true
+      }`,
+    },
+    
+    // Single spread at beginning
+    {
+      code: `const obj = {
+        ...userOptions,
+        name: 'defaultName',
+        age: 25
+      }`,
+    },
+    
+    // Single spread only
+    {
+      code: 'const obj = { ...userOptions }',
+    },
+    
+    // Computed property with spread first
+    {
+      code: `const obj = {
+        ...options,
+        [key]: 'value'
+      }`,
+    },
+    
+    // Method with spread first
+    {
+      code: `const obj = {
+        ...options,
+        method() { return 'value' }
+      }`,
+    },
+  ],
+
+  invalid: [
+    // Spread after regular property
+    {
+      code: `const obj = {
+        name: 'defaultName',
+        ...userOptions
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+    
+    // Spread after computed property
+    {
+      code: `const obj = {
+        [key]: 'value',
+        ...userOptions
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+    
+    // Spread after method
+    {
+      code: `const obj = {
+        getValue() { return 'default' },
+        ...userOptions
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+    
+    // Spread after another spread (your case)
+    {
+      code: `const obj = {
+        ...base,
+        ...fields
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+    
+    // Multiple spreads after first spread
+    {
+      code: `const obj = {
+        ...obj1,
+        ...obj2,
+        ...obj3
+      }`,
+      errors: [
+        {
+          message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+          type: 'SpreadElement',
+        },
+        {
+          message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+          type: 'SpreadElement',
+        },
+      ],
+    },
+    
+    // Mixed case: property, spread, property, spread
+    {
+      code: `const obj = {
+        name: 'default',
+        ...base,
+        age: 25,
+        ...userOptions
+      }`,
+      errors: [
+        {
+          message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+          type: 'SpreadElement',
+        },
+        {
+          message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+          type: 'SpreadElement',
+        },
+      ],
+    },
+    
+    // Real-world TypeScript case (our EventCreators pattern)
+    {
+      code: `const newEvaluationEvent = (base, fields) => {
+        return {
+          ...base,
+          ...fields,
+          '@type': 'EvaluationEvent'
+        }
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+    
+    // Spread after property with final property
+    {
+      code: `const obj = {
+        name: 'default',
+        ...userOptions,
+        '@type': 'Event'
+      }`,
+      errors: [{
+        message: 'Spreading objects after default properties can override defaults with undefined values. Consider using nullish coalescing (??) instead.',
+        type: 'SpreadElement',
+      }],
+    },
+  ],
+})
+
+console.log('✅ All tests passed!')

--- a/eslint-rules/no-spread-after-defaults.test.js
+++ b/eslint-rules/no-spread-after-defaults.test.js
@@ -173,4 +173,4 @@ ruleTester.run('no-spread-after-defaults', rule.rules['no-spread-after-defaults'
   ],
 })
 
-console.log('✅ All tests passed!')
+console.log('✅ no-spread-after-defaults tests completed successfully')

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -13,6 +13,7 @@ module.exports = [
       'eslint.config.cjs',
       'node_modules',
       'tsconfig.json',
+      'build.config.ts',
       '**/*.d.ts',
     '.github',
     'eslint-rules/',
@@ -24,7 +25,7 @@ module.exports = [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: './tsconfig.json',
+        projectService: true,
         tsconfigRootDir: __dirname,
         sourceType: 'module',
       },

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,48 +1,61 @@
-const eslintConfigPrettier = require('eslint-config-prettier');
-const tsParser = require('@typescript-eslint/parser');
-const tsEslint = require('@typescript-eslint/eslint-plugin');
-const tseslint = require('typescript-eslint');
+const eslintConfigPrettier = require('eslint-config-prettier')
+const tsParser = require('@typescript-eslint/parser')
+const tsEslint = require('@typescript-eslint/eslint-plugin')
+const tseslint = require('typescript-eslint')
 
 module.exports = [
-	{
-		files: ['**/*.ts', 'src/**/*.js', '**/*.cjs'],
-	},
-	{
-		ignores: [
-			'dist',
-			'eslint.config.cjs',
-			'node_modules',
-			'tsconfig.json',
-		]
-	},
-	...tseslint.configs.recommended,
-	eslintConfigPrettier,
-	{
-		languageOptions: {
-			parser: tsParser,
-		}
-	},
-	{
-		rules: {
-			'no-multiple-empty-lines': 'error',
-			quotes: ['error', 'single', { allowTemplateLiterals: true }],
-			semi: ['error', 'never'],
-			'@typescript-eslint/no-unused-vars': [
-				'warn',
-				{
-					argsIgnorePattern: '^_',
-					varsIgnorePattern: '^_',
-					caughtErrorsIgnorePattern: '^_',
-					destructuredArrayIgnorePattern: '^_',
-				},
-			],
-			'@typescript-eslint/no-unused-expressions': [
-				'error',
-				{
-					allowShortCircuit: true,
-					allowTernary: true,
-				},
-			],
-		},
-	}
-];
+  {
+    files: ['**/*.ts', 'src/**/*.js', '**/*.cjs'],
+  },
+  {
+    ignores: [
+      'dist',
+      'eslint.config.cjs',
+      'node_modules',
+      'tsconfig.json',
+      '**/*.d.ts',
+    '.github',
+    'eslint-rules/',
+    ],
+  },
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+        sourceType: 'module',
+      },
+    },
+  },
+  {
+    plugins: {
+      'custom-rules': require('./eslint-rules/no-spread-after-defaults.js').default,
+    },
+    rules: {
+      'no-multiple-empty-lines': 'error',
+      quotes: ['error', 'single', { allowTemplateLiterals: true }],
+      semi: ['error', 'never'],
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        {
+          allowShortCircuit: true,
+          allowTernary: true,
+        },
+      ],
+      '@typescript-eslint/prefer-nullish-coalescing': ['error'],
+      'custom-rules/no-spread-after-defaults': 'error',
+    },
+  },
+]

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:e2e:node": "cp -f ./e2e/module.node.ts ./e2e/module.ts ; vitest --config ./vitest-e2e-node.config.ts --dir e2e",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "test:custom-eslint-rules": "node eslint-rules/no-spread-after-defaults.test.js",
     "example:serve": "pnpm exec unbuild && pnpm --filter example serve"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "devDependencies": {
     "@types/jsdom": "21.1.7",
     "@types/node": "22.17.0",
-    "@typescript-eslint/eslint-plugin": "8.38.0",
-    "@typescript-eslint/parser": "8.38.0",
+    "@typescript-eslint/eslint-plugin": "8.39.0",
+    "@typescript-eslint/parser": "8.39.0",
     "@vitest/browser": "3.2.4",
     "@vitest/utils": "3.2.4",
     "eslint": "9.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,11 +19,11 @@ importers:
         specifier: 22.17.0
         version: 22.17.0
       '@typescript-eslint/eslint-plugin':
-        specifier: 8.38.0
-        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+        specifier: 8.39.0
+        version: 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/parser':
-        specifier: 8.38.0
-        version: 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+        specifier: 8.39.0
+        version: 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       '@vitest/browser':
         specifier: 3.2.4
         version: 3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.9.2))(vite@7.0.6(@types/node@22.17.0)(jiti@2.5.1))(vitest@3.2.4)(webdriverio@9.18.4)
@@ -38,7 +38,7 @@ importers:
         version: 10.1.8(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))
+        version: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-prettier:
         specifier: 5.5.3
         version: 5.5.3(eslint-config-prettier@10.1.8(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(prettier@3.6.2)
@@ -634,6 +634,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/eslint-plugin@8.39.0':
+    resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.39.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@8.38.0':
     resolution: {integrity: sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -641,14 +649,31 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/parser@8.39.0':
+    resolution: {integrity: sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/project-service@8.38.0':
     resolution: {integrity: sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/project-service@8.39.0':
+    resolution: {integrity: sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@8.38.0':
     resolution: {integrity: sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.39.0':
+    resolution: {integrity: sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.38.0':
@@ -657,6 +682,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/tsconfig-utils@8.39.0':
+    resolution: {integrity: sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/type-utils@8.38.0':
     resolution: {integrity: sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -664,8 +695,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/type-utils@8.39.0':
+    resolution: {integrity: sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/types@8.38.0':
     resolution: {integrity: sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.39.0':
+    resolution: {integrity: sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.38.0':
@@ -674,6 +716,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/typescript-estree@8.39.0':
+    resolution: {integrity: sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@8.38.0':
     resolution: {integrity: sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -681,8 +729,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@8.39.0':
+    resolution: {integrity: sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@8.38.0':
     resolution: {integrity: sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.39.0':
+    resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/browser@3.2.4':
@@ -3485,12 +3544,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.39.0
+      '@typescript-eslint/type-utils': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.39.0
+      eslint: 9.32.0(jiti@2.5.1)
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.38.0
+      debug: 4.4.1
+      eslint: 9.32.0(jiti@2.5.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.39.0
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
       typescript: 5.9.2
@@ -3506,12 +3594,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.39.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.0
+      debug: 4.4.1
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.38.0':
     dependencies:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
 
+  '@typescript-eslint/scope-manager@8.39.0':
+    dependencies:
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/visitor-keys': 8.39.0
+
   '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -3527,7 +3633,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      debug: 4.4.1
+      eslint: 9.32.0(jiti@2.5.1)
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.38.0': {}
+
+  '@typescript-eslint/types@8.39.0': {}
 
   '@typescript-eslint/typescript-estree@8.38.0(typescript@5.9.2)':
     dependencies:
@@ -3535,6 +3655,22 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -3556,9 +3692,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
+      '@typescript-eslint/scope-manager': 8.39.0
+      '@typescript-eslint/types': 8.39.0
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      eslint: 9.32.0(jiti@2.5.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.38.0':
     dependencies:
       '@typescript-eslint/types': 8.38.0
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.39.0':
+    dependencies:
+      '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
 
   '@vitest/browser@3.2.4(msw@2.10.4(@types/node@22.17.0)(typescript@5.9.2))(vite@7.0.6(@types/node@22.17.0)(jiti@2.5.1))(vitest@3.2.4)(webdriverio@9.18.4)':
@@ -4356,17 +4508,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4377,7 +4529,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4389,7 +4541,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -90,19 +90,21 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     userAgent: config.userAgent ?? userAgent,
     fetch: config.fetch ?? fetch,
     storageFactory: config.storageFactory ?? createBKTStorage,
-    // Advanced properties: only included when explicitly set (not undefined)
-    // to prevent overriding internal defaults or leaking undefined values
-    ...(config.wrapperSdkVersion !== undefined && {
-      wrapperSdkVersion: config.wrapperSdkVersion,
-    }),
-    ...(config.wrapperSdkSourceId !== undefined && {
-      wrapperSdkSourceId: config.wrapperSdkSourceId,
-    }),
-    ...(config.idGenerator !== undefined && {
-      idGenerator: config.idGenerator,
-    }),
   }
 
+  // Advanced properties: only included when explicitly set (not undefined)
+  // to prevent overriding internal defaults or leaking undefined values
+  if (config.wrapperSdkVersion !== undefined) {
+    result.wrapperSdkVersion = config.wrapperSdkVersion
+  }
+  if (config.wrapperSdkSourceId !== undefined) {
+    result.wrapperSdkSourceId = config.wrapperSdkSourceId
+  }
+  if (config.idGenerator !== undefined) {
+    result.idGenerator = config.idGenerator
+  }
+
+  // Validate required properties
   if (!result.apiKey) throw new IllegalArgumentException('apiKey is required')
   if (!result.apiEndpoint)
     throw new IllegalArgumentException('apiEndpoint is required')
@@ -111,7 +113,7 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
   if (!result.appVersion)
     throw new IllegalArgumentException('appVersion is required')
 
-  if (!result.fetch || typeof result.fetch !== 'function') {
+  if (typeof result.fetch !== 'function') {
     throw new IllegalArgumentException(
       'fetch is required: no fetch implementation was provided or no global fetch is available. ' +
         'Please provide a fetch implementation in the config (e.g., node-fetch in Node.js environments).',

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -110,10 +110,13 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     throw new IllegalArgumentException('apiEndpoint is invalid')
   if (!result.appVersion)
     throw new IllegalArgumentException('appVersion is required')
-  
-  // Internal check: make sure fetch is defined even if not provided, defaults to global fetch.
-  // This is to ensure that the SDK has a fetch implementation available
-  if (!result.fetch) throw new IllegalArgumentException('fetch is required')
+
+  if (typeof result.fetch !== 'function') {
+    throw new IllegalArgumentException(
+      'fetch is required: no fetch implementation was provided and no global fetch is available. ' +
+      'Please provide a fetch implementation in the config (e.g., node-fetch in Node.js environments).'
+    )
+  }
 
   // Special handling for userAgent: empty string should use default
   if (!result.userAgent) {

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -111,10 +111,10 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
   if (!result.appVersion)
     throw new IllegalArgumentException('appVersion is required')
 
-  if (typeof result.fetch !== 'function') {
+  if (!result.fetch || typeof result.fetch !== 'function') {
     throw new IllegalArgumentException(
-      'fetch is required: no fetch implementation was provided and no global fetch is available. ' +
-      'Please provide a fetch implementation in the config (e.g., node-fetch in Node.js environments).'
+      'fetch is required: no fetch implementation was provided or no global fetch is available. ' +
+        'Please provide a fetch implementation in the config (e.g., node-fetch in Node.js environments).',
     )
   }
 

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -110,6 +110,9 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     throw new IllegalArgumentException('apiEndpoint is invalid')
   if (!result.appVersion)
     throw new IllegalArgumentException('appVersion is required')
+  
+  // Internal check: make sure fetch is defined even if not provided, defaults to global fetch.
+  // This is to ensure that the SDK has a fetch implementation available
   if (!result.fetch) throw new IllegalArgumentException('fetch is required')
 
   // Special handling for userAgent: empty string should use default

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -82,17 +82,25 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     apiEndpoint: config.apiEndpoint,
     appVersion: config.appVersion,
     featureTag: config.featureTag ?? '',
-    eventsFlushInterval: config.eventsFlushInterval ?? MINIMUM_FLUSH_INTERVAL_MILLIS,
+    eventsFlushInterval:
+      config.eventsFlushInterval ?? MINIMUM_FLUSH_INTERVAL_MILLIS,
     eventsMaxQueueSize: config.eventsMaxQueueSize ?? DEFAULT_MAX_QUEUE_SIZE,
     pollingInterval: config.pollingInterval ?? DEFAULT_POLLING_INTERVAL_MILLIS,
     storageKeyPrefix: config.storageKeyPrefix ?? '',
     userAgent: config.userAgent ?? userAgent,
     fetch: config.fetch ?? fetch,
     storageFactory: config.storageFactory ?? createBKTStorage,
-    // Only include wrapper properties if they're explicitly provided (not undefined)
-    ...(config.wrapperSdkVersion !== undefined && { wrapperSdkVersion: config.wrapperSdkVersion }),
-    ...(config.wrapperSdkSourceId !== undefined && { wrapperSdkSourceId: config.wrapperSdkSourceId }),
-    ...(config.idGenerator !== undefined && { idGenerator: config.idGenerator }),
+    // Advanced properties: only included when explicitly set (not undefined)
+    // to prevent overriding internal defaults or leaking undefined values
+    ...(config.wrapperSdkVersion !== undefined && {
+      wrapperSdkVersion: config.wrapperSdkVersion,
+    }),
+    ...(config.wrapperSdkSourceId !== undefined && {
+      wrapperSdkSourceId: config.wrapperSdkSourceId,
+    }),
+    ...(config.idGenerator !== undefined && {
+      idGenerator: config.idGenerator,
+    }),
   }
 
   if (!result.apiKey) throw new IllegalArgumentException('apiKey is required')
@@ -102,15 +110,6 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     throw new IllegalArgumentException('apiEndpoint is invalid')
   if (!result.appVersion)
     throw new IllegalArgumentException('appVersion is required')
-
-  // Special handling for fetch: if explicitly set to undefined, it should throw
-  if ('fetch' in config && config.fetch === undefined) {
-    throw new IllegalArgumentException('fetch is required')
-  }
-  // If the final config does not have fetch, throw an error
-  // This ensures that the fetch function is always defined
-  // and available for making network requests.
-  // This is important for the SDK to function correctly.
   if (!result.fetch) throw new IllegalArgumentException('fetch is required')
 
   // Special handling for userAgent: empty string should use default

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -104,7 +104,7 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     throw new IllegalArgumentException('appVersion is required')
 
   // Special handling for fetch: if explicitly set to undefined, it should throw
-  if (config.hasOwnProperty('fetch') && config.fetch === undefined) {
+  if (Object.prototype.hasOwnProperty.call(config, 'fetch') && config.fetch === undefined) {
     throw new IllegalArgumentException('fetch is required')
   }
   if (!result.fetch) throw new IllegalArgumentException('fetch is required')

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -88,7 +88,7 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     pollingInterval: config.pollingInterval ?? DEFAULT_POLLING_INTERVAL_MILLIS,
     storageKeyPrefix: config.storageKeyPrefix ?? '',
     userAgent: config.userAgent ?? userAgent,
-    fetch: config.fetch ?? fetch,
+    fetch: config.fetch ?? globalThis.fetch,
     storageFactory: config.storageFactory ?? createBKTStorage,
   }
 

--- a/src/BKTConfig.ts
+++ b/src/BKTConfig.ts
@@ -104,9 +104,13 @@ export const defineBKTConfig = (config: RawBKTConfig): BKTConfig => {
     throw new IllegalArgumentException('appVersion is required')
 
   // Special handling for fetch: if explicitly set to undefined, it should throw
-  if (Object.prototype.hasOwnProperty.call(config, 'fetch') && config.fetch === undefined) {
+  if ('fetch' in config && config.fetch === undefined) {
     throw new IllegalArgumentException('fetch is required')
   }
+  // If the final config does not have fetch, throw an error
+  // This ensures that the fetch function is always defined
+  // and available for making network requests.
+  // This is important for the SDK to function correctly.
   if (!result.fetch) throw new IllegalArgumentException('fetch is required')
 
   // Special handling for userAgent: empty string should use default

--- a/src/internal/di/Component.ts
+++ b/src/internal/di/Component.ts
@@ -21,7 +21,7 @@ export class DefaultComponent implements Component {
     public platformModule: PlatformModule,
     public dataModule: DataModule,
     public interactorModule: InteractorModule,
-  ) { }
+  ) {}
 
   config(): BKTConfig {
     return this.dataModule.config()
@@ -32,31 +32,26 @@ export class DefaultComponent implements Component {
   }
 
   evaluationInteractor(): EvaluationInteractor {
-    if (!this._evaluationInteractor) {
-      this._evaluationInteractor = this.interactorModule.evaluationInteractor(
+    return (this._evaluationInteractor ??=
+      this.interactorModule.evaluationInteractor(
         this.dataModule.config().featureTag,
         this.dataModule.apiClient(),
         this.dataModule.evaluationStorage(),
         this.platformModule.idGenerator(),
-      )
-    }
-    return this._evaluationInteractor
+      ))
   }
 
   eventInteractor(): EventInteractor {
-    if (!this._eventInteractor) {
-      this._eventInteractor = this.interactorModule.eventInteractor(
-        this.dataModule.config().eventsMaxQueueSize,
-        this.dataModule.apiClient(),
-        this.dataModule.eventStorage(),
-        this.platformModule.idGenerator(),
-        this.dataModule.clock(),
-        this.dataModule.config().appVersion,
-        this.dataModule.config().userAgent,
-        this.dataModule.config().sourceId,
-        this.dataModule.config().sdkVersion,
-      )
-    }
-    return this._eventInteractor
+    return (this._eventInteractor ??= this.interactorModule.eventInteractor(
+      this.dataModule.config().eventsMaxQueueSize,
+      this.dataModule.apiClient(),
+      this.dataModule.eventStorage(),
+      this.platformModule.idGenerator(),
+      this.dataModule.clock(),
+      this.dataModule.config().appVersion,
+      this.dataModule.config().userAgent,
+      this.dataModule.config().sourceId,
+      this.dataModule.config().sdkVersion,
+    ))
   }
 }

--- a/src/internal/di/DataModule.ts
+++ b/src/internal/di/DataModule.ts
@@ -31,10 +31,7 @@ export class DataModule {
   }
 
   clock(): Clock {
-    if (!this._clock) {
-      this._clock = new DefaultClock()
-    }
-    return this._clock
+    return (this._clock ??= new DefaultClock())
   }
 
   apiClient(): ApiClient {
@@ -52,24 +49,20 @@ export class DataModule {
   }
 
   evaluationStorage(): EvaluationStorage {
-    if (!this._evaluationStorage) {
-      const config = this.config()
-      this._evaluationStorage = new EvaluationStorageImpl(
-        this.userHolder().userId,
-        config.storageFactory(`${config.storageKeyPrefix}_bkt_evaluations`),
-      )
-    }
-    return this._evaluationStorage
+    return (this._evaluationStorage ??= new EvaluationStorageImpl(
+      this.userHolder().userId,
+      this.config().storageFactory(
+        `${this.config().storageKeyPrefix}_bkt_evaluations`,
+      ),
+    ))
   }
 
   eventStorage(): EventStorage {
-    if (!this._eventStorage) {
-      const config = this.config()
-      this._eventStorage = new EventStorageImpl(
-        this.userHolder().userId,
-        config.storageFactory(`${config.storageKeyPrefix}_bkt_events`),
-      )
-    }
-    return this._eventStorage
+    return (this._eventStorage ??= new EventStorageImpl(
+      this.userHolder().userId,
+      this.config().storageFactory(
+        `${this.config().storageKeyPrefix}_bkt_events`,
+      ),
+    ))
   }
 }

--- a/src/internal/di/PlatformModule.browser.ts
+++ b/src/internal/di/PlatformModule.browser.ts
@@ -6,9 +6,6 @@ export class BrowserPlatformModule implements PlatformModule {
   protected _idGenerator?: IdGenerator
 
   idGenerator() {
-    if (!this._idGenerator) {
-      this._idGenerator = new BrowserIdGenerator()
-    }
-    return this._idGenerator
+    return (this._idGenerator ??= new BrowserIdGenerator())
   }
 }

--- a/src/internal/di/PlatformModule.node.ts
+++ b/src/internal/di/PlatformModule.node.ts
@@ -6,9 +6,6 @@ export class NodePlatformModule implements PlatformModule {
   protected _idGenerator?: IdGenerator
 
   idGenerator() {
-    if (!this._idGenerator) {
-      this._idGenerator = new NodeIdGenerator()
-    }
-    return this._idGenerator
+    return (this._idGenerator ??= new NodeIdGenerator())
   }
 }

--- a/src/internal/event/EventCreators.ts
+++ b/src/internal/event/EventCreators.ts
@@ -52,6 +52,9 @@ export const newEvaluationEvent = (
 ): EvaluationEvent => {
   return {
     ...base,
+    // Safe to spread fields after base: TypeScript ensures fields cannot contain
+    // BaseEvent properties or '@type', preventing undefined value overrides.
+    // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.EvaluationEvent,
   }
@@ -63,6 +66,9 @@ export const newDefaultEvaluationEvent = (
 ): EvaluationEvent => {
   return {
     ...base,
+    // Safe to spread fields after base: BaseEvent and EvaluationEvent 
+    // are not containing any undefined values,
+    // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.EvaluationEvent,
   }
@@ -74,6 +80,9 @@ export const newGoalEvent = (
 ): GoalEvent => {
   return {
     ...base,
+    // Safe to spread fields after base: BaseEvent and GoalEvent 
+    // are not containing any undefined values,
+    // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.GoalEvent,
   }
@@ -146,6 +155,9 @@ export const newMetricsEvent = (
 ): MetricsEvent => {
   return {
     ...base,
+    // Safe to spread fields after base: BaseEvent and MetricsEvent 
+    // are not containing any undefined values,
+    // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.MetricsEvent,
   }

--- a/src/internal/event/EventCreators.ts
+++ b/src/internal/event/EventCreators.ts
@@ -52,8 +52,8 @@ export const newEvaluationEvent = (
 ): EvaluationEvent => {
   return {
     ...base,
-    // Safe to spread fields after base: TypeScript ensures fields cannot contain
-    // BaseEvent properties or '@type', preventing undefined value overrides.
+    // TypeScript's Omit ensures fields cannot override BaseEvent properties
+    // This spread is safe and creates a clean composition pattern
     // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.EvaluationEvent,
@@ -66,8 +66,8 @@ export const newDefaultEvaluationEvent = (
 ): EvaluationEvent => {
   return {
     ...base,
-    // Safe to spread fields after base: BaseEvent and EvaluationEvent 
-    // are not containing any undefined values,
+    // TypeScript's Omit ensures fields cannot override BaseEvent properties
+    // This spread is safe and creates a clean composition pattern
     // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.EvaluationEvent,
@@ -80,8 +80,8 @@ export const newGoalEvent = (
 ): GoalEvent => {
   return {
     ...base,
-    // Safe to spread fields after base: BaseEvent and GoalEvent 
-    // are not containing any undefined values,
+    // TypeScript's Omit ensures fields cannot override BaseEvent properties
+    // This spread is safe and creates a clean composition pattern
     // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.GoalEvent,
@@ -155,8 +155,8 @@ export const newMetricsEvent = (
 ): MetricsEvent => {
   return {
     ...base,
-    // Safe to spread fields after base: BaseEvent and MetricsEvent 
-    // are not containing any undefined values,
+    // TypeScript's Omit ensures fields cannot override BaseEvent properties
+    // This spread is safe and creates a clean composition pattern
     // eslint-disable-next-line custom-rules/no-spread-after-defaults
     ...fields,
     '@type': RootEventType.MetricsEvent,

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -126,13 +126,15 @@ suite('defineBKTConfig', () => {
     }
   })
 
-  test('explicitly passing undefined to fetch field throws', () => {
+  test('explicitly passing undefined to fetch field will not throws', () => {
+    // fetch is optional, so passing undefined should not throw
+    // the global fetch will be used
     expect(() => {
       defineBKTConfig({
         ...defaultConfig,
         fetch: undefined,
       })
-    }).toThrow(IllegalArgumentException)
+    }).not.toThrow(IllegalArgumentException)
   })
 
   test('explicitly passing undefined to featureTag results in empty string', () => {

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -1,12 +1,12 @@
 import { suite, test, expect } from 'vitest'
-import { defineBKTConfig } from '../src/BKTConfig'
+import { defineBKTConfig, type RawBKTConfig } from '../src/BKTConfig'
 import { IllegalArgumentException } from '../src/BKTExceptions'
 import { createBKTStorage } from '../src/BKTStorage'
 import { SDK_VERSION } from '../src/internal/version'
 import { SourceId } from '../src/internal/model/SourceId'
 import type { InternalConfig } from '../src/internal/InternalConfig'
 
-const defaultConfig: Parameters<typeof defineBKTConfig>[0] = {
+const defaultConfig: RawBKTConfig = {
   apiKey: 'api-key',
   apiEndpoint: 'https://example.com',
   featureTag: 'feature-tag',
@@ -142,6 +142,53 @@ suite('defineBKTConfig', () => {
     })
 
     expect(result.featureTag).toBe('')
+  })
+
+  test('should use default values when config properties are undefined', () => {
+    // Test case 1: eventsMaxQueueSize should default to 50 when undefined
+    const configWithUndefinedMaxQueue: RawBKTConfig = {
+      ...defaultConfig,
+      eventsMaxQueueSize: undefined,
+    }
+    
+    const result1 = defineBKTConfig(configWithUndefinedMaxQueue)
+    expect(result1.eventsMaxQueueSize).toBe(50)
+
+    // Test case 2: storageKeyPrefix should default to '' when undefined
+    const configWithUndefinedStoragePrefix: RawBKTConfig = {
+      ...defaultConfig,
+      storageKeyPrefix: undefined,
+    }
+    
+    const result2 = defineBKTConfig(configWithUndefinedStoragePrefix)
+    expect(result2.storageKeyPrefix).toBe('')
+
+    // Test case 3: pollingInterval should default to 600_000 when undefined
+    const configWithUndefinedPolling: RawBKTConfig = {
+      ...defaultConfig,
+      pollingInterval: undefined,
+    }
+    
+    const result3 = defineBKTConfig(configWithUndefinedPolling)
+    expect(result3.pollingInterval).toBe(600_000)
+
+    // Test case 4: eventsFlushInterval should default to 30_000 when undefined
+    const configWithUndefinedFlush: RawBKTConfig = {
+      ...defaultConfig,
+      eventsFlushInterval: undefined,
+    }
+    
+    const result4 = defineBKTConfig(configWithUndefinedFlush)
+    expect(result4.eventsFlushInterval).toBe(30_000)
+
+    // Test case 5: storageFactory should default to createBKTStorage when undefined
+    const configWithUndefinedStorageFactory: RawBKTConfig = {
+      ...defaultConfig,
+      storageFactory: undefined,
+    }
+    
+    const result5 = defineBKTConfig(configWithUndefinedStorageFactory)
+    expect(result5.storageFactory).toBe(createBKTStorage)
   })
 
   test('invalid apiEndpoint throws', () => {

--- a/test/BKTConfig.spec.ts
+++ b/test/BKTConfig.spec.ts
@@ -126,7 +126,7 @@ suite('defineBKTConfig', () => {
     }
   })
 
-  test('explicitly passing undefined to fetch field will not throws', () => {
+  test('explicitly passing undefined to fetch field will not throw', () => {
     // fetch is optional, so passing undefined should not throw
     // the global fetch will be used
     expect(() => {

--- a/test/internal/remote/ApiClient.spec.ts
+++ b/test/internal/remote/ApiClient.spec.ts
@@ -179,7 +179,7 @@ suite('internal/remote/ApiClient', () => {
         expect(response.type).toBe('failure')
         expect(response.featureTag).toBe('feature_tag_value')
 
-        const error = response.error || null
+        const error = response.error ?? null
 
         assert(error instanceof TimeoutException)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,16 @@
 {
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
   "files": [],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "e2e/**/*.ts",
+    "example/**/*.ts",
+    "*.ts",
+    "*.cjs"
+  ],
   "references": [
     {
       "path": "./tsconfig.config.json"
@@ -10,5 +21,5 @@
     {
       "path": "./tsconfig.vitest.json"
     }
-  ],
+  ]
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
-    "noEmit": true,
+    "noEmit": false,
     "emitDeclarationOnly": false
   },
   "include": ["src", "test", "e2e", "types/vitest.d.ts"]


### PR DESCRIPTION
# Changes
- This PR fixed the bug "Undefined Values Override Defaults in `defineBKTConfig`"
- Also add a custom lint rule to prevent this issue in the future

## Bug Report: Undefined Values Override Defaults in `defineBKTConfig`

### Issue Summary
The `defineBKTConfig` function has a critical bug where the spread operator `...config` can override default values with `undefined`, causing properties that should have defaults to become undefined and potentially break the application.

It was related to an issue found in the React Native SDK: [the SDK is not using InMemoryStorage when AsyncStorage not available](https://github.com/bucketeer-io/react-native-client-sdk/pull/1/commits/3bc197fef13816d309ac07e806c8613934d8edbd)

### Root Cause
**Location**: `src/BKTConfig.ts`, line 88
```typescript
const result: BKTConfig = {
  featureTag: '',
  eventsFlushInterval: MINIMUM_FLUSH_INTERVAL_MILLIS,
  eventsMaxQueueSize: DEFAULT_MAX_QUEUE_SIZE,
  pollingInterval: DEFAULT_POLLING_INTERVAL_MILLIS,
  storageKeyPrefix: '',
  userAgent,
  fetch,
  storageFactory: createBKTStorage,
  ...config, // BUG: This can override defaults with undefined values
}
```

The spread operation happens **after** setting defaults, so any property in `config` that is explicitly set to `undefined` will override the intended default value.

### Affected Properties

#### Properties with NO validation (can remain undefined):
- `eventsMaxQueueSize` - No check, can be undefined
- `storageKeyPrefix` - No check, can be undefined  
- `storageFactory` - No check, can be undefined

#### Properties with inadequate validation:
- `pollingInterval` - Uses `< MINIMUM_POLLING_INTERVAL_MILLIS` check, but `undefined < number` is `false`, so undefined passes through
- `eventsFlushInterval` - Same issue as above

#### Properties with working validation:
- `featureTag` - Has explicit `=== undefined` check
- `userAgent` - Has `!result.userAgent` check
- `fetch` - Has `!result.fetch` check that throws error

### How to Reproduce

```typescript
import { defineBKTConfig } from './src/BKTConfig'

// Example 1: storageFactory becomes undefined
const config1 = {
  apiKey: 'test-key',
  apiEndpoint: 'https://api.example.com',
  appVersion: '1.0.0',
  storageFactory: undefined, // This overrides the default createBKTStorage
}

const result1 = defineBKTConfig(config1)
console.log(result1.storageFactory) // undefined (should be createBKTStorage)

// Example 2: eventsMaxQueueSize becomes undefined
const config2 = {
  apiKey: 'test-key',
  apiEndpoint: 'https://api.example.com',
  appVersion: '1.0.0',
  eventsMaxQueueSize: undefined, // This overrides the default 50
}

const result2 = defineBKTConfig(config2)
console.log(result2.eventsMaxQueueSize) // undefined (should be 50)

// Example 3: pollingInterval becomes undefined (bypasses validation)
const config3 = {
  apiKey: 'test-key',
  apiEndpoint: 'https://api.example.com',
  appVersion: '1.0.0',
  pollingInterval: undefined, // This overrides the default, and undefined < 60000 is false
}

const result3 = defineBKTConfig(config3)
console.log(result3.pollingInterval) // undefined (should be 600000)

// Example 4: Multiple undefined values causing issues
const config4 = {
  apiKey: 'test-key',
  apiEndpoint: 'https://api.example.com',
  appVersion: '1.0.0',
  eventsMaxQueueSize: undefined,
  storageKeyPrefix: undefined,
  pollingInterval: undefined,
  eventsFlushInterval: undefined,
}

const result4 = defineBKTConfig(config4)
// All these properties will be undefined instead of their defaults:
console.log(result4.eventsMaxQueueSize)  // undefined (should be 50)
console.log(result4.storageKeyPrefix)    // undefined (should be '')
console.log(result4.pollingInterval)     // undefined (should be 600000)
console.log(result4.eventsFlushInterval) // undefined (should be 30000)
```

### Impact
- Runtime errors when undefined properties are used
- Inconsistent behavior between properties
- Type safety violation (TypeScript thinks properties are non-nullable, but they can be undefined)
- Potential crashes when calling methods on undefined objects (e.g., `storageFactory`)
