### PR TITLE
fix: fall back when id_generator return wrong uuidv4

### DIFF
--- a/e2e/idGenerator.browser.spec.ts
+++ b/e2e/idGenerator.browser.spec.ts
@@ -1,0 +1,149 @@
+import { afterEach, assert, expect, suite, test, vi } from 'vitest'
+import { BKTClient, BKTClientImpl } from '../src/BKTClient'
+import { BKTConfig, defineBKTConfig } from '../src/BKTConfig'
+import { BKTUser, defineBKTUser } from '../src/BKTUser'
+import { DefaultComponent } from '../src/internal/di/Component'
+import { UUID_V4_REGEX } from '../src/utils/regex'
+import {
+  FEATURE_ID_STRING,
+  GOAL_ID,
+  GOAL_VALUE,
+  USER_ID,
+} from './constants'
+import { fetchLike } from './environment'
+
+const VALID_UUID_V3 = 'ed92afad-81f1-394b-be77-347c7e170fa9'
+
+type BrowserSdk = typeof import('../src/main.browser')
+
+let destroyBKTClient: BrowserSdk['destroyBKTClient'] | undefined
+const originalRandomUUID = globalThis.crypto.randomUUID
+
+const loadBrowserSdk = async (): Promise<BrowserSdk> => {
+  // Vitest gives us module reset before dynamic import, which is the simplest
+  // way to start each scenario from a clean module state before client
+  // initialization, where BrowserIdGenerator checks randomUUID support.
+  vi.resetModules()
+  const sdk = await import('../src/main.browser')
+  destroyBKTClient = sdk.destroyBKTClient
+  return sdk
+}
+
+const createConfig = (storageKeyPrefix: string): BKTConfig =>
+  defineBKTConfig({
+    apiEndpoint: import.meta.env.VITE_BKT_API_ENDPOINT,
+    apiKey: import.meta.env.VITE_BKT_API_KEY,
+    featureTag: 'javascript',
+    appVersion: '1.2.3',
+    fetch: fetchLike,
+    storageKeyPrefix,
+  })
+
+const createUser = (): BKTUser =>
+  defineBKTUser({
+    id: USER_ID,
+  })
+
+const getDefaultComponent = (client: BKTClient): DefaultComponent => {
+  return (client as BKTClientImpl).component as DefaultComponent
+}
+
+const expectStoredEventIdsToBeUuidV4 = async (
+  client: BKTClient,
+): Promise<DefaultComponent> => {
+  const component = getDefaultComponent(client)
+  const events = await component.dataModule.eventStorage().getAll()
+
+  expect(events.length).toBeGreaterThan(0)
+  events.forEach((event) => {
+    expect(event.id).toMatch(UUID_V4_REGEX)
+  })
+
+  return component
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  globalThis.crypto.randomUUID = originalRandomUUID
+  destroyBKTClient?.()
+  destroyBKTClient = undefined
+})
+
+suite('e2e/idGenerator.browser', () => {
+  test('falls back when randomUUID is unavailable', async () => {
+    // @ts-expect-error - testing browser runtime without randomUUID
+    globalThis.crypto.randomUUID = undefined
+
+    const sdk = await loadBrowserSdk()
+
+    await sdk.initializeBKTClient(
+      createConfig('id-generator-browser-unavailable'),
+      createUser(),
+    )
+
+    const client = sdk.getBKTClient()
+
+    assert(client != null)
+
+    expect(client.stringVariation(FEATURE_ID_STRING, '')).toBe('value-1')
+    await client.track(GOAL_ID, GOAL_VALUE)
+
+    const component = await expectStoredEventIdsToBeUuidV4(client)
+
+    await client.flush()
+
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
+  })
+
+  test('falls back when randomUUID returns an invalid uuid v4', async () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(VALID_UUID_V3)
+
+    const sdk = await loadBrowserSdk()
+
+    await sdk.initializeBKTClient(
+      createConfig('id-generator-browser-invalid'),
+      createUser(),
+    )
+
+    const client = sdk.getBKTClient()
+
+    assert(client != null)
+
+    expect(client.stringVariation(FEATURE_ID_STRING, '')).toBe('value-1')
+    await client.track(GOAL_ID, GOAL_VALUE)
+
+    const component = await expectStoredEventIdsToBeUuidV4(client)
+
+    await client.flush()
+
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
+  })
+
+  test('falls back to Math.random when both randomUUID and getRandomValues are unavailable', async () => {
+    // @ts-expect-error - testing browser runtime without randomUUID
+    globalThis.crypto.randomUUID = undefined
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(() => {
+      throw new Error('getRandomValues unavailable')
+    })
+
+    const sdk = await loadBrowserSdk()
+
+    await sdk.initializeBKTClient(
+      createConfig('id-generator-browser-math-random'),
+      createUser(),
+    )
+
+    const client = sdk.getBKTClient()
+
+    assert(client != null)
+
+    expect(client.stringVariation(FEATURE_ID_STRING, '')).toBe('value-1')
+    await client.track(GOAL_ID, GOAL_VALUE)
+
+    const component = await expectStoredEventIdsToBeUuidV4(client)
+
+    await client.flush()
+
+    expect(await component.dataModule.eventStorage().getAll()).toHaveLength(0)
+  })
+})

--- a/src/internal/IdGenerator.browser.ts
+++ b/src/internal/IdGenerator.browser.ts
@@ -1,7 +1,106 @@
+import { UUID_V4_REGEX } from '../utils/regex'
 import { IdGenerator } from './IdGenerator'
 
+const toHex = (value: number): string => value.toString(16).padStart(2, '0')
+
+// Applies the RFC 4122 v4 version and variant bits to a 16-byte array and
+// returns a formatted UUID string.  The caller is responsible for supplying
+// the random bytes; this function only handles layout and formatting.
+const formatUuidV4 = (bytes: Uint8Array): string => {
+  // RFC 4122 / UUID v4 bits
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex = Array.from(bytes, toHex)
+
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-')
+}
+
+// Tier 2: fills 16 bytes using `crypto.getRandomValues`.
+//
+// We prefer this over `randomUUID` because `randomUUID` cannot be relied upon
+// to always return a valid v4 UUID:
+//
+//   - Insecure contexts (HTTP): `randomUUID` is restricted to secure contexts
+//     and will throw or be undefined (MDN); `getRandomValues` still works.
+//   - Enterprise environments: corporate IT policies can hook into `randomUUID`
+//     and change the UUID version or format.
+//   - Browser extensions: extensions can monkey-patch `crypto.randomUUID` on
+//     the page context, producing non-standard output.
+//   - Incorrect polyfills: a third-party polyfill may return a non-v4 UUID.
+//   - Older / non-standard runtimes: embedded WebViews or browsers older than
+//     Chrome 92 / Safari 15.4 may not implement `randomUUID` at all.
+//
+// We apply the RFC 4122 v4 bit layout to `getRandomValues` output ourselves,
+// so the format is always under our control.
+const randomBytesFromGetRandomValues = (): Uint8Array => {
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return bytes
+}
+
+// Tier 3: fills 16 bytes using `Math.random` as a last-resort fallback.
+//
+// This is intentionally the weakest source of randomness in the chain.
+// `Math.random` provides roughly 53 bits of precision per call, which is
+// significantly less than the 128 bits of entropy produced by Web Crypto.
+// Collisions are therefore more likely than with the tier-2 path — but still
+// negligible across realistic event volumes within a single session.
+//
+// This fallback exists for deeply broken runtimes where `crypto.getRandomValues`
+// is absent or throws (e.g. stripped-down embedded WebViews, aggressive
+// enterprise lockdown, or broken polyfills).  In those environments, delivering
+// events with weaker IDs is preferable to dropping them silently.
+//
+// `Math.random` is always available on any JavaScript runtime, so this path
+// will never throw.
+const randomBytesFromMathRandom = (): Uint8Array =>
+  Uint8Array.from({ length: 16 }, () => Math.floor(Math.random() * 256))
+
+// Evaluates whether native `crypto.randomUUID` is suitable for UUID v4
+// generation at the point this function is called.  The result is cached as a
+// class field so the check runs exactly once per `BrowserIdGenerator` instance
+// (and therefore once per SDK initialisation, because the platform module
+// memoises the generator).
+//
+// Performing the check at construction time rather than at module-load time
+// means test environments can control `globalThis.crypto` with plain spies —
+// no `vi.resetModules()` required.
+function checkNativeRandomUUID(): boolean {
+  if (typeof globalThis.crypto?.randomUUID !== 'function') return false
+  try {
+    // `randomUUID` is restricted to secure contexts and will throw (or be
+    // undefined) on http — fall back to `getRandomValues`.
+    return UUID_V4_REGEX.test(globalThis.crypto.randomUUID())
+  } catch {
+    return false
+  }
+}
+
 export class BrowserIdGenerator implements IdGenerator {
+  // Validated once at construction time.  No per-call re-validation; if
+  // `randomUUID` later regresses the server will reject the malformed ID,
+  // which is the correct signal for a misconfigured environment.
+  private readonly useNativeRandomUUID: boolean = checkNativeRandomUUID()
+
   newId(): string {
-    return crypto.randomUUID()
+    // Tier 1: validated native randomUUID (decided once at construction).
+    if (this.useNativeRandomUUID) {
+      return globalThis.crypto.randomUUID()
+    }
+
+    // Tier 2: getRandomValues with manual RFC 4122 v4 layout.
+    // Tier 3: Math.random as a last-resort for broken/missing Web Crypto.
+    try {
+      return formatUuidV4(randomBytesFromGetRandomValues())
+    } catch {
+      return formatUuidV4(randomBytesFromMathRandom())
+    }
   }
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,2 @@
+export const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i

--- a/test/internal/IdGenerator.browser.spec.ts
+++ b/test/internal/IdGenerator.browser.spec.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BrowserIdGenerator } from '../../src/internal/IdGenerator.browser'
+import { UUID_V4_REGEX } from '../../src/utils/regex'
+
+const VALID_UUID_V4 = '123e4567-e89b-42d3-a456-426614174000'
+const VALID_UUID_V3 = 'ed92afad-81f1-394b-be77-347c7e170fa9'
+
+describe('BrowserIdGenerator', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('UUID_V4_REGEX', () => {
+    it('matches valid UUID v4', () => {
+      expect(VALID_UUID_V4).toMatch(UUID_V4_REGEX)
+    })
+
+    it('does not match valid UUID v3 (wrong version digit)', () => {
+      expect(VALID_UUID_V3).not.toMatch(UUID_V4_REGEX)
+    })
+
+    it('does not match invalid UUID strings', () => {
+      expect('not-a-uuid').not.toMatch(UUID_V4_REGEX)
+      expect('123e4567-e89b-12d3-a456-426614174000').not.toMatch(UUID_V4_REGEX) // v1
+    })
+
+    it('matches actual output from crypto.randomUUID()', () => {
+      expect(globalThis.crypto.randomUUID()).toMatch(UUID_V4_REGEX)
+    })
+  })
+
+  it('uses native randomUUID when it returns a valid uuid v4', () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(VALID_UUID_V4)
+    const gen = new BrowserIdGenerator()
+
+    const getRandomValuesSpy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+    const result = gen.newId()
+
+    expect(result).toBe(VALID_UUID_V4)
+    expect(getRandomValuesSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to getRandomValues when randomUUID returns an invalid uuid v4', () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(VALID_UUID_V3)
+    const gen = new BrowserIdGenerator()
+
+    const getRandomValuesSpy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+    const result = gen.newId()
+
+    expect(result).not.toBe(VALID_UUID_V3)
+    expect(result).toMatch(UUID_V4_REGEX)
+    expect(getRandomValuesSpy).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to getRandomValues when randomUUID returns undefined', () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
+      undefined as unknown as ReturnType<typeof globalThis.crypto.randomUUID>,
+    )
+    const gen = new BrowserIdGenerator()
+
+    const getRandomValuesSpy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+    const result = gen.newId()
+
+    expect(result).toMatch(UUID_V4_REGEX)
+    expect(getRandomValuesSpy).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to getRandomValues when randomUUID is not a function', () => {
+    const originalRandomUUID = globalThis.crypto.randomUUID
+    // @ts-expect-error - testing invalid environment
+    globalThis.crypto.randomUUID = undefined
+
+    try {
+      const gen = new BrowserIdGenerator()
+      const getRandomValuesSpy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+      const result = gen.newId()
+      expect(result).toMatch(UUID_V4_REGEX)
+      expect(getRandomValuesSpy).toHaveBeenCalledOnce()
+    } finally {
+      globalThis.crypto.randomUUID = originalRandomUUID
+    }
+  })
+
+  it('does not re-check randomUUID validity on subsequent newId() calls', () => {
+    const randomUUIDSpy = vi
+      .spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValue(VALID_UUID_V4)
+    const gen = new BrowserIdGenerator()
+
+    gen.newId()
+    gen.newId()
+    gen.newId()
+
+    // 1 call during construction + 3 calls from newId()
+    expect(randomUUIDSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('always uses getRandomValues fallback on every newId() call when randomUUID is unavailable', () => {
+    const originalRandomUUID = globalThis.crypto.randomUUID
+    // @ts-expect-error - testing invalid environment
+    globalThis.crypto.randomUUID = undefined
+
+    try {
+      const gen = new BrowserIdGenerator()
+
+      const getRandomValuesSpy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+
+      const results = [gen.newId(), gen.newId(), gen.newId()]
+
+      results.forEach((r) => expect(r).toMatch(UUID_V4_REGEX))
+      expect(getRandomValuesSpy).toHaveBeenCalledTimes(3)
+    } finally {
+      globalThis.crypto.randomUUID = originalRandomUUID
+    }
+  })
+
+  it('falls back to Math.random when getRandomValues throws', () => {
+    // Make randomUUID throw so the constructor sets useNativeRandomUUID = false.
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => {
+      throw new Error('randomUUID unavailable')
+    })
+    const gen = new BrowserIdGenerator()
+
+    // Mock getRandomValues after construction so the constructor is unaffected.
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(() => {
+      throw new Error('getRandomValues unavailable')
+    })
+
+    // Make Math.random deterministic so we can prove it was called, not just
+    // infer it from the UUID format.
+    const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const result = gen.newId()
+
+    expect(result).toMatch(UUID_V4_REGEX)
+    expect(mathRandomSpy).toHaveBeenCalled()
+  })
+
+  it('always uses Math.random fallback on every newId() call when both crypto APIs are unavailable', () => {
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => {
+      throw new Error('randomUUID unavailable')
+    })
+    const gen = new BrowserIdGenerator()
+
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(() => {
+      throw new Error('getRandomValues unavailable')
+    })
+
+    const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    const results = [gen.newId(), gen.newId(), gen.newId()]
+
+    results.forEach((r) => expect(r).toMatch(UUID_V4_REGEX))
+    // 16 bytes per call × 3 calls
+    expect(mathRandomSpy).toHaveBeenCalledTimes(48)
+  })
+})
+

--- a/test/setup.browser.ts
+++ b/test/setup.browser.ts
@@ -1,10 +1,11 @@
-import { randomUUID } from 'node:crypto'
+import { randomUUID, webcrypto } from 'node:crypto'
 import { afterEach } from 'vitest'
 
-// setup crypto.randomUUID
+// setup crypto APIs used by the browser generator
 Object.defineProperty(global.self, 'crypto', {
   value: {
-    randomUUID: randomUUID,
+    randomUUID,
+    getRandomValues: webcrypto.getRandomValues.bind(webcrypto),
   },
 })
 

--- a/vitest-e2e-node.config.ts
+++ b/vitest-e2e-node.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import packageJson from './package.json'
 
 export default defineConfig({
@@ -8,5 +8,12 @@ export default defineConfig({
   test: {
     setupFiles: ['e2e/setup.node.ts'],
     environment: 'node',
+    // Exclude browser-only tests that use `vi.resetModules` and browser globals (crypto)
+    // from the Node.js E2E suite to avoid runtime errors and unnecessary execution.
+    exclude: [
+      // Preserve Vitest's default exclusions (node_modules, dist, etc.)
+      ...configDefaults.exclude,
+      'e2e/idGenerator.browser.spec.ts',
+    ],
   },
 })


### PR DESCRIPTION
#319 

## Issue: `crypto.randomUUID` may return non-v4 UUIDs in certain environments

`crypto.randomUUID` is a high-level API that returns a formatted UUID string, but its output is not guaranteed to always be a v4 UUID in every environment:

- **Insecure contexts (HTTP):** per MDN, `randomUUID` is restricted to secure contexts and will throw or be undefined, while `getRandomValues` continues to work.
- **Enterprise environments:** there is Edge Enterprise version that the corporate IT policies can override or hook browser APIs, potentially changing the UUID version or format returned by `randomUUID`.
- **Browser extensions:** extensions can monkey-patch `crypto.randomUUID` on the page context, producing non-standard output.
- **Incorrect polyfills:** a third-party polyfill may implement `randomUUID` incorrectly and return a non-v4 UUID.
- **Older / non-standard runtimes:** embedded WebViews or older browser versions may not implement `randomUUID` at all (it was added in Chrome 92 / Safari 15.4).

**Why do we still trust `crypto.getRandomValues`?**
- We apply the RFC 4122 v4 bit layout to the output of `getRandomValues` ourselves, so the output format is always under our control.
- Per MDN, `getRandomValues` is the only crypto API guaranteed to work in insecure contexts.
- Both APIs can be polyfilled, but if `getRandomValues` is broken, many other web APIs will likely be broken too — making it a more reliable signal of a non-compliant environment.

**What changed:**
The SDK validates the output of `crypto.randomUUID` when BrowserIdGenerator is constructed (during client initialization). If the value is not a valid v4 UUID (or if the call fails), we fall back to our internal UUID v4 generator built on `getRandomValues` or `Match.random()`