### PR TITLE
fix: latency metrics should reflect only the most recent (final) network request attempt

### DIFF
--- a/src/internal/remote/ApiClient.ts
+++ b/src/internal/remote/ApiClient.ts
@@ -46,7 +46,10 @@ export class ApiClientImpl implements ApiClient {
     }
 
     try {
-      const startMillis = latencyStartMillis()
+      let startMillis = latencyStartMillis()
+      const onAttemptStart = (): void => {
+        startMillis = latencyStartMillis()
+      }
 
       const res = await postInternal(
         `${this.endpoint}/get_evaluations`,
@@ -54,6 +57,7 @@ export class ApiClientImpl implements ApiClient {
         body,
         this.fetch,
         timeoutMillis,
+        onAttemptStart,
       )
 
       const seconds = latencySecondsSince(startMillis)

--- a/src/internal/remote/post.ts
+++ b/src/internal/remote/post.ts
@@ -3,12 +3,30 @@ import { FetchLike, FetchRequestLike, FetchResponseLike } from './fetch'
 import { promiseRetriable, RetryPolicy } from './PromiseRetriable'
 import { addTimeoutValueIfNeeded, toBKTException } from './toBKTException'
 
+/**
+ * Sends a POST request with automatic retry on deployment-related 499 errors.
+ *
+ * @param onAttemptStart - Optional callback invoked at the start of **each** attempt
+ *   (including the first and every retry). Use this hook when you need a measurement
+ *   that reflects only the most-recent attempt — for example, resetting a latency timer
+ *   so that backoff delays and prior failed attempts are excluded from the final value.
+ *
+ *   Example — accurate per-attempt latency:
+ *   ```ts
+ *   let startMillis = latencyStartMillis()
+ *   await postInternal(endpoint, headers, body, fetch, timeoutMillis,
+ *     () => { startMillis = latencyStartMillis() }
+ *   )
+ *   const seconds = latencySecondsSince(startMillis) // reflects the last attempt only
+ *   ```
+ */
 export const postInternal = async (
   endpoint: string,
   headers: FetchRequestLike['headers'],
   body: object,
   fetch: FetchLike,
   timeoutMillis: number,
+  onAttemptStart?: () => void,
 ): Promise<FetchResponseLike> => {
   const retryPolicy: RetryPolicy = {
     maxRetries: 3,
@@ -21,13 +39,18 @@ export const postInternal = async (
   }
   // Default retry logic when we got a deployment-related 499 error
   return promiseRetriable(
-    () => _postInternal(
-      endpoint,
-      headers,
-      body,
-      fetch,
-      timeoutMillis,
-    ),
+    () => {
+      // Notify the caller that a new attempt is starting before issuing the request.
+      // This allows the caller to reset any per-attempt state (e.g. a latency timer).
+      onAttemptStart?.()
+      return _postInternal(
+        endpoint,
+        headers,
+        body,
+        fetch,
+        timeoutMillis,
+      )
+    },
     retryPolicy,
     shouldRetry,
   )

--- a/test/internal/remote/ApiClientEvaluationLatency.spec.ts
+++ b/test/internal/remote/ApiClientEvaluationLatency.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { ApiClientImpl } from '../../../src/internal/remote/ApiClient'
+import { FetchLike } from '../../../src/internal/remote/fetch'
+import { SourceId } from '../../../src/internal/model/SourceId'
+import { SDK_VERSION } from '../../../src/internal/version'
+import { user1 } from '../../mocks/users'
+
+describe('ApiClientImpl - Evaluation Latency', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+
+  it('should measure getEvaluations seconds from the last attempt only', async () => {
+    vi.useFakeTimers()
+
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+    const mockFetch = vi.fn<FetchLike>()
+
+    // Keep postInternal real and mock only fetch, so retries still trigger
+    // onAttemptStart and the test measures final-attempt latency correctly.
+    mockFetch
+      .mockImplementationOnce(async () => {
+        now += 25
+        return {
+          ok: false,
+          status: 499,
+          statusText: 'Client Closed Request',
+          headers: {
+            get: () => null,
+          },
+          text: () => Promise.resolve('{"error": {"message": "Client Closed Request"}}'),
+          json: () => Promise.resolve({ error: { message: 'Client Closed Request' } }),
+        }
+      })
+      .mockImplementationOnce(async () => {
+        now += 12
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: {
+            get: (name: string) => name === 'Content-Length' ? '10' : null,
+          },
+          json: () => Promise.resolve({
+            evaluations: [],
+            userEvaluationsId: 'test_id',
+          }),
+          text: () => Promise.resolve(''),
+        }
+      })
+
+    const apiClient = new ApiClientImpl(
+      'https://api.example.com',
+      'test_api_key',
+      mockFetch,
+      SourceId.JAVASCRIPT,
+      SDK_VERSION,
+    )
+
+    const responsePromise = apiClient.getEvaluations({
+      user: user1,
+      userEvaluationsId: 'test_id',
+      tag: 'test_tag',
+      userEvaluationCondition: {
+        evaluatedAt: '0',
+        userAttributesUpdated: false,
+      },
+    })
+
+    await Promise.resolve()
+    now += 1000
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const response = await responsePromise
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(response.type).toBe('success')
+    if (response.type !== 'success') {
+      throw new Error(`expected success, got ${response.type}`)
+    }
+    expect(response.seconds).toBeCloseTo(0.012, 6)
+  })
+})

--- a/test/internal/remote/ApiClientImpl.spec.ts
+++ b/test/internal/remote/ApiClientImpl.spec.ts
@@ -67,5 +67,9 @@ describe('ApiClientImpl', () => {
       30000, // default timeout
       expect.any(Function),
     )
+    const onAttemptStart = spy.mock.calls[0][5]
+    expect(onAttemptStart).toHaveLength(0)
+    expect(onAttemptStart).toBeDefined()
+    expect(onAttemptStart!()).toBeUndefined()
   })
 })

--- a/test/internal/remote/ApiClientImpl.spec.ts
+++ b/test/internal/remote/ApiClientImpl.spec.ts
@@ -65,6 +65,7 @@ describe('ApiClientImpl', () => {
       },
       fetch,
       30000, // default timeout
+      expect.any(Function),
     )
   })
 })

--- a/test/internal/remote/post.spec.ts
+++ b/test/internal/remote/post.spec.ts
@@ -69,4 +69,104 @@ describe('postInternal', () => {
     expect(result.ok).toBe(true)
     expect(result.status).toBe(200)
   })
+
+  it('should call onAttemptStart once when request succeeds without retry', async () => {
+    const mockFetch = vi.fn<FetchLike>()
+    const onAttemptStart = vi.fn()
+    const endpoint = 'https://api.example.com/test'
+    const headers = { 'Content-Type': 'application/json' }
+    const body = { key: 'value' }
+    const timeoutMillis = 5000
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const result = await postInternal(
+      endpoint,
+      headers,
+      body,
+      mockFetch,
+      timeoutMillis,
+      onAttemptStart,
+    )
+
+    expect(onAttemptStart).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+  })
+
+  it('should call onAttemptStart on each attempt including retries', async () => {
+    const mockFetch = vi.fn<FetchLike>()
+    const onAttemptStart = vi.fn()
+    const endpoint = 'https://api.example.com/test'
+    const headers = { 'Content-Type': 'application/json' }
+    const body = { key: 'value' }
+    const timeoutMillis = 5000
+
+    const response499 = {
+      ok: false,
+      status: 499,
+      statusText: 'Client Closed Request',
+      text: () => Promise.resolve('{"error": {"message": "Client Closed Request"}}'),
+      json: () => Promise.resolve({ error: { message: 'Client Closed Request' } }),
+    } as Response
+
+    mockFetch
+      .mockResolvedValueOnce(response499)
+      .mockResolvedValueOnce(response499)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as Response)
+
+    const resultPromise = postInternal(
+      endpoint,
+      headers,
+      body,
+      mockFetch,
+      timeoutMillis,
+      onAttemptStart,
+    )
+
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(1000)
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(2000)
+
+    const result = await resultPromise
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(onAttemptStart).toHaveBeenCalledTimes(3)
+    expect(result.ok).toBe(true)
+  })
+
+  it('should work normally when onAttemptStart is not provided', async () => {
+    const mockFetch = vi.fn<FetchLike>()
+    const endpoint = 'https://api.example.com/test'
+    const headers = { 'Content-Type': 'application/json' }
+    const body = { key: 'value' }
+    const timeoutMillis = 5000
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const result = await postInternal(endpoint, headers, body, mockFetch, timeoutMillis)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe(200)
+  })
 })


### PR DESCRIPTION
This pull request improves how per-attempt latency is measured for API requests that may be retried, ensuring that latency metrics reflect only the most recent (final) attempt rather than the total time including retries and backoff delays.